### PR TITLE
Playwright links.js

### DIFF
--- a/playwright/links.js
+++ b/playwright/links.js
@@ -1,0 +1,57 @@
+// Copyright 2023-2024 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Import the Chromium browser into our scraper.
+import { chromium } from 'playwright';
+
+// browserAddress
+const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
+
+// web serveur url
+const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'https://en.wikipedia.org/wiki/Web_browser';
+
+// measure general time.
+const gstart = process.hrtime.bigint();
+// store all run durations
+let metrics = [];
+
+// Connect to an existing browser
+console.log("Connection to browser on " + browserAddress);
+const browser = await chromium.connectOverCDP({
+    endpointURL: browserAddress,
+    logger: {
+      isEnabled: (name, severity) => true,
+      log: (name, severity, message, args) => console.log(`${name} ${message}`)
+    }
+});
+
+
+const context = await browser.newContext({
+    baseURL: baseURL,
+});
+
+const page = await context.newPage();
+await page.goto(baseURL);
+
+const links = await page.getByRole('link').evaluateAll(links =>
+  links.map(link => link.getAttribute('href'))
+);
+
+console.log(links);
+
+await page.close();
+await context.close();
+
+// Turn off the browser to clean up after ourselves.
+await browser.close();

--- a/runner/main.go
+++ b/runner/main.go
@@ -108,6 +108,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"playwright/connect.js"}},
 		{Bin: "node", Args: []string{"playwright/cdp.js"}, Env: []string{"RUNS=2"}},
 		{Bin: "node", Args: []string{"playwright/dump.js"}},
+		{Bin: "node", Args: []string{"playwright/links.js"}, Env: []string{"BASE_URL=http://127.0.0.1:1234/campfire-commerce/"}},
 		{Bin: "node", Args: []string{"playwright/click.js"}},
 		{Bin: "go", Args: []string{"run", "fetch/main.go", "http://127.0.0.1:1234/"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "links/main.go", "http://127.0.0.1:1234/"}, Dir: "chromedp"},


### PR DESCRIPTION
Depends on: https://github.com/lightpanda-io/browser/pull/721, https://github.com/lightpanda-io/browser/pull/760

Playwright also works with the same code as Puppeteer, but using `getByRole` shows that it also works via this route.
```
const links = await page.evaluate(() => {
  return Array.from(document.querySelectorAll('a')).map(row => {
    return row.getAttribute('href');
  });
});
```