### PR TITLE
Fix waiting logic for playwright request inteception

### DIFF
--- a/playwright/request_interception.js
+++ b/playwright/request_interception.js
@@ -57,7 +57,10 @@ await page.route('**', async (route, request) => {
 });
 await page.goto('/nope/');
 
-await page.waitForSelector('#response', {timeout: 5000});
+await page.waitForFunction(() => {
+	return document.getElementById('response').textContent.length > 0
+}, {timeout: 5000});
+
 const response = await page.locator('#response').textContent();
 const data = JSON.parse(response);
 


### PR DESCRIPTION
Previously we were just waiting on '#response' being present, but it's _always_ there - it's part of the pages HTML. Changed to wait for it to have content (which is loaded by the xhr request).