### PR TITLE
Tweak chromedp fetch test

### DIFF
--- a/chromedp/fetch/main.go
+++ b/chromedp/fetch/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/chromedp/chromedp"
 )
@@ -102,6 +103,12 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("new tab: %w", err)
 	}
 
+	is_test := false
+	if url == "test" {
+		url = "http://127.0.0.1:1234/campfire-commerce/"
+		is_test = true
+	}
+
 	err := chromedp.Run(ctx, chromedp.Navigate(url))
 	if err != nil {
 		return fmt.Errorf("navigate %s: %w", url, err)
@@ -113,7 +120,14 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("outerHTML: %w", err)
 	}
 
-	stdout.Write([]byte(content))
+	if is_test {
+		expected := "<html><head>\n\t<title>Outdoor Odyssey Nomad Backpack</title>"
+		if strings.HasPrefix(content, expected) == false {
+			return fmt.Errorf("Invalid HTML: %s", content)
+		}
+	} else {
+		stdout.Write([]byte(content))
+	}
 
 	return nil
 }

--- a/runner/main.go
+++ b/runner/main.go
@@ -113,7 +113,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"playwright/links.js"}, Env: []string{"BASE_URL=http://127.0.0.1:1234/campfire-commerce/"}},
 		{Bin: "node", Args: []string{"playwright/click.js"}},
 		{Bin: "node", Args: []string{"playwright/request_interception.js"}},
-		{Bin: "go", Args: []string{"run", "fetch/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},
+		{Bin: "go", Args: []string{"run", "fetch/main.go", "test"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "links/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "click/main.go", "http://127.0.0.1:1234/"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "ri/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},


### PR DESCRIPTION
When run with the "test" URL, it loads http://127.0.0.1:1234/campfire-commerce/ and actually verify's the content (like the existing dump tests). runner/main.go uses the "test" url. This make the test a bit more accurate - making sure we got the expected content instead of just any content. It also helps to reduce the output noise by not dumping the html to stdout.