### PR TITLE
Add `helpers.js` for Puppeteer

### DIFF
--- a/puppeteer/authenticate.js
+++ b/puppeteer/authenticate.js
@@ -14,24 +14,14 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-// ws address
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 
 // web serveur url
 const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
 
-
 (async () => {
-  // Connect to the browser and open a new blank page
-  let opts = {};
-  if (browserAddress.substring(0, 5) == 'ws://') {
-      opts.browserWSEndpoint = browserAddress;
-  } else {
-      opts.browserURL = browserAddress;
-  }
-
-  const browser = await puppeteer.connect(opts);
+  const browser = await connectBrowser();
   const context = await browser.createBrowserContext();
   const page = await context.newPage();
 

--- a/puppeteer/basic.js
+++ b/puppeteer/basic.js
@@ -14,14 +14,11 @@
 'use scrict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/form/get.html';
 
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-    browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/cdp.js
+++ b/puppeteer/cdp.js
@@ -14,9 +14,7 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
-
-// ws address
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
+import { connectBrowser } from './helpers.js'
 
 // web serveur url
 const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
@@ -31,14 +29,7 @@ let metrics = [];
 
 (async () => {
   // Connect to the browser and open a new blank page
-  let opts = {};
-  if (browserAddress.substring(0, 5) == 'ws://') {
-      opts.browserWSEndpoint = browserAddress;
-  } else {
-      opts.browserURL = browserAddress;
-  }
-
-  const browser = await puppeteer.connect(opts);
+  const browser = await connectBrowser();
 
   for (var run = 0; run<runs; run++) {
     // measure run time.

--- a/puppeteer/click.js
+++ b/puppeteer/click.js
@@ -15,18 +15,9 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-// ws address
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
-
-// Connect to the browser and open a new blank page
-let opts = {};
-if (browserAddress.substring(0, 5) == 'ws://') {
-    opts.browserWSEndpoint = browserAddress;
-} else {
-    opts.browserURL = browserAddress;
-}
-const browser = await puppeteer.connect(opts);
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/console-log.js
+++ b/puppeteer/console-log.js
@@ -14,13 +14,9 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/cookies-fetch.js
+++ b/puppeteer/cookies-fetch.js
@@ -15,13 +15,9 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();
 const page = await context.newPage();

--- a/puppeteer/cookies-redirect-local.js
+++ b/puppeteer/cookies-redirect-local.js
@@ -15,10 +15,9 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-const browser = await puppeteer.connect({
-  browserWSEndpoint: 'ws://127.0.0.1:9222',
-});
+const browser = await connectBrowser();
 
 const context = await browser.createBrowserContext();
 const page = await context.newPage();

--- a/puppeteer/cookies-redirect.js
+++ b/puppeteer/cookies-redirect.js
@@ -15,10 +15,9 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-const browser = await puppeteer.connect({
-  browserWSEndpoint: 'ws://127.0.0.1:9222',
-});
+const browser = await connectBrowser();
 
 const context = await browser.createBrowserContext();
 const page = await context.newPage();

--- a/puppeteer/cookies-xhr.js
+++ b/puppeteer/cookies-xhr.js
@@ -15,13 +15,10 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
+const browser = await connectBrowser();
 
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();
 const page = await context.newPage();

--- a/puppeteer/cookies.js
+++ b/puppeteer/cookies.js
@@ -14,14 +14,11 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/campfire-commerce/';
+const browser = await connectBrowser();
 
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();
 const page = await context.newPage();

--- a/puppeteer/dump.js
+++ b/puppeteer/dump.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'https://wikipedia.com';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/dynamic_scripts.js
+++ b/puppeteer/dynamic_scripts.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const baseURL = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234'
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-    browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/form.js
+++ b/puppeteer/form.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const baseURL = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234'
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-    browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/frame.js
+++ b/puppeteer/frame.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/frames/index.html';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/helpers.js
+++ b/puppeteer/helpers.js
@@ -11,25 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 'use strict'
 
 import puppeteer from 'puppeteer-core';
-import { connectBrowser } from './helpers.js'
 
-const url = process.env.URL ? process.env.URL : 'https://example.com';
-const browser = await connectBrowser();
+const browserAddress = process.env.BROWSER_ADDRESS ?? 'ws://127.0.0.1:9222';
 
-// The rest of your script remains the same.
-const context = await browser.createBrowserContext();
-const page = await context.newPage();
-const client = page._client();
+export async function connectBrowser() {
+    const opts = browserAddress.startsWith('ws://')
+        ? { browserWSEndpoint: browserAddress }
+        : { browserURL: browserAddress };
 
-await page.goto(url, { waitUntil: 'networkidle0'});
-
-const axtree = await client.send('Accessibility.getFullAXTree', {});
-console.log(JSON.stringify(axtree));
-
-await page.close();
-await context.close();
-await browser.disconnect();
-
+    return puppeteer.connect(opts);
+}

--- a/puppeteer/links.js
+++ b/puppeteer/links.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'https://en.wikipedia.org/wiki/Web_browser';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/location_write.js
+++ b/puppeteer/location_write.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const baseURL = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234'
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-    browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/magic8ball.js
+++ b/puppeteer/magic8ball.js
@@ -14,9 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/magic8ball/';
+const browser = await connectBrowser();
 
 const expectedAnswers = [
     'It is certain.',
@@ -36,11 +37,6 @@ const expectedAnswers = [
     'Absolutely not.',
     'The stars say yes.',
 ];
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-    browserWSEndpoint: browserAddress,
-});
 
 // runs
 const runs = process.env.RUNS ? parseInt(process.env.RUNS) : 100;

--- a/puppeteer/markdown.js
+++ b/puppeteer/markdown.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://demo-browser.lightpanda.io/campfire-commerce/';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/multi.js
+++ b/puppeteer/multi.js
@@ -14,13 +14,13 @@
 'use scrict'
 
 import puppeteer from 'puppeteer-core'
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/form/get.html';
 
 // First of all, create multiple connections at the same time
 const browsers = await Promise.all(Array.from(new Array(10)).map(() => {
-  return puppeteer.connect({ browserWSEndpoint: browserAddress });
+  return connectBrowser();
 }));
 
 // For each connection, create a context

--- a/puppeteer/pending-page.js
+++ b/puppeteer/pending-page.js
@@ -15,14 +15,10 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/proxy_auth.js
+++ b/puppeteer/proxy_auth.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'https://wikipedia.com';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/request_interception.js
+++ b/puppeteer/request_interception.js
@@ -14,24 +14,13 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
-
-// ws address
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
+import { connectBrowser } from './helpers.js'
 
 // web serveur url
 const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
 
-
 (async () => {
-  // Connect to the browser and open a new blank page
-  let opts = {};
-  if (browserAddress.substring(0, 5) == 'ws://') {
-      opts.browserWSEndpoint = browserAddress;
-  } else {
-      opts.browserURL = browserAddress;
-  }
-
-  const browser = await puppeteer.connect(opts);
+  const browser = await connectBrowser();
   const context = await browser.createBrowserContext();
   const page = await context.newPage();
 

--- a/puppeteer/ri_authenticate.js
+++ b/puppeteer/ri_authenticate.js
@@ -14,24 +14,14 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
-
-// ws address
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
+import { connectBrowser } from './helpers.js'
 
 // web serveur url
 const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
 
 
 (async () => {
-  // Connect to the browser and open a new blank page
-  let opts = {};
-  if (browserAddress.substring(0, 5) == 'ws://') {
-      opts.browserWSEndpoint = browserAddress;
-  } else {
-      opts.browserURL = browserAddress;
-  }
-
-  const browser = await puppeteer.connect(opts);
+  const browser = await connectBrowser();
   const context = await browser.createBrowserContext();
   const page = await context.newPage();
 

--- a/puppeteer/screenshot.js
+++ b/puppeteer/screenshot.js
@@ -14,13 +14,9 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-  browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();

--- a/puppeteer/ua.js
+++ b/puppeteer/ua.js
@@ -2,10 +2,9 @@
 
 import puppeteer from 'puppeteer-core';
 import assert from 'assert';
+import { connectBrowser } from './helpers.js'
 
-const browser = await puppeteer.connect({
-  browserWSEndpoint: 'ws://127.0.0.1:9222',
-});
+const browser = await connectBrowser();
 
 const context = await browser.createBrowserContext();
 const page = await context.newPage();

--- a/puppeteer/wait_for_network.js
+++ b/puppeteer/wait_for_network.js
@@ -14,14 +14,10 @@
 'use strict'
 
 import puppeteer from 'puppeteer-core';
+import { connectBrowser } from './helpers.js'
 
-const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 const url = process.env.URL ? process.env.URL : 'https://httpbin.io/xhr/get';
-
-// use browserWSEndpoint to pass the Lightpanda's CDP server address.
-const browser = await puppeteer.connect({
-    browserWSEndpoint: browserAddress,
-});
+const browser = await connectBrowser();
 
 // The rest of your script remains the same.
 const context = await browser.createBrowserContext();


### PR DESCRIPTION
There is a lot of duplication (and sometimes stuff that doesn't work the same across different scripts) in a lot of the puppeteer scripts. This introduces a `puppeteer/helpers.js` that has a `connectBrowser` that standardizes the browser connection logic, ensuring all of them behave the same in that regard.