### PR TITLE
hack: Make console test backwards compatible with previous event type

### DIFF
--- a/puppeteer/console-log.js
+++ b/puppeteer/console-log.js
@@ -29,7 +29,11 @@ page.on('console', (evt) => {
   if (evt.type() == "error") {
     err = true;
   }
-  if (evt.type() == "log") {
+  // TODO: remove '|| evt.type() == "info"'
+  // This is only added since we have some PRs based on commits prior to
+  // https://github.com/lightpanda-io/browser/pull/2731 which changed the type
+  // from info to log
+  if (evt.type() == "log" || evt.type() == "info") {
     log = true;
   }
 });


### PR DESCRIPTION
Since we still have some PRs in browser which are based off of a commits prior to the change in console log types (1), this makes the change previous done in (2) more generous by supporting both types

(1) https://github.com/lightpanda-io/browser/pull/2731 
(2) 6da5841e17a2df4da18ad514b57667810c77121