### PR TITLE
wptrunner: disable http cache

### DIFF
--- a/wptrunner/browser.go
+++ b/wptrunner/browser.go
@@ -73,7 +73,6 @@ func (b *ProcessBrowser) Start(ctx context.Context) error {
 		"--log-level", "error",
 		"--port", strconv.Itoa(b.Port),
 		"--insecure-disable-tls-host-verification",
-		"--http-cache-dir", "/tmp/lp-cache/",
 	)
 
 	// We keep a reference to the original context to restart the browser with


### PR DESCRIPTION
reverts 5a8dd229c7973c95c5d54607dbfba3bd233662ec This only appears to slow down the full WPT run. Worth investigating separately, but for now, no reason to keep this on.