### PR TITLE
Add lightpanda agent regression suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can find script examples to use the browser with different librairies.
 
 * `runner/` contains a Go program running many of examples scripts against local demo website
 * `integration/` contains a Go program running scripts against real world websites.
+* `agent/` contains the `lightpanda agent` regression suite (deterministic script replay against the `public/` demo sites + a live LLM layer).
 
 ## Tools
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,101 @@
+# Agent regression suite
+
+End-to-end regression tests for `lightpanda agent`, running against the demo
+sites that already live in `public/` — no dedicated fixtures. The **browser
+repo's CI** checks demo out and drives this suite, the same way the
+runner/integration/wpt suites work. Two layers, so the cheap deterministic
+checks can gate every browser PR while the expensive keyed checks run
+nightly / on demand.
+
+```
+agent/
+  run.sh                 orchestrator (bash + jq + the demo runner server)
+  scripts/campfire.js    golden PandaScript: campfire-commerce product page
+  scripts/amiibo.js      golden PandaScript: amiibo front page -> item crawl
+  golden/<name>.json     exact expected replay output per script
+  cases/static-qa.tsv    <task>\t<expected-substring> per line
+  cases/hn-live.task     task prompt for the live HN case (pins the contract)
+  cases/hn-live.jq       shape invariant verifying that contract
+```
+
+The target sites (`public/campfire-commerce/`, `public/amiibo/`) are
+**JS-rendered shells** — scripts fetch JSON and fill the DOM — so the
+deterministic layer exercises script execution, `fetch`, and DOM manipulation
+on top of navigation and extraction. Both are fully deterministic (fixed JSON
+data). They are served by the existing demo runner (`runner/main.go -serve`,
+`public/` on `127.0.0.1:1234`), which run.sh builds and starts itself.
+
+## Layers
+
+### Deterministic (no API key, gates every browser PR)
+
+Replays every script in `scripts/` and diffs the returned JSON **exactly**
+against its `golden/<name>.json`:
+
+- `campfire.js` — single-page extract of the product name, price, features,
+  related products, and reviews (waits on the two async renders).
+- `amiibo.js` — front page → item pages crawl via the "See also" links, the
+  same shape as the live Hacker News case.
+
+### Live (needs `GOOGLE_API_KEY` or `GEMINI_API_KEY`, nightly / on demand)
+
+Drives the real Gemini-backed agent:
+
+- **Static Q&A** — for each row in `cases/static-qa.tsv`, run
+  `lightpanda agent --task "<question about campfire-commerce>"` and assert
+  the expected substring appears in the answer. Closed-form answers make the
+  substring match robust to LLM phrasing.
+- **HN save + replay** — ask the agent (task in `cases/hn-live.task`) to
+  scrape live Hacker News and `/save` a reproducible script, then replay that
+  script **token-free** and validate the output against `cases/hn-live.jq`
+  (a *shape* invariant: exactly 5 stories, non-empty titles, ≤3 comments each
+  with non-empty `user`/`text`, and at least one story with a comment). We
+  can't assert exact values because the live site and the LLM both vary — so
+  the task prompt pins the output contract and the schema verifies it; edit
+  those two files together.
+
+The stable `$usage total=N` line lightpanda prints to stderr is captured per
+task; a loose `MAX_TOKENS` ceiling flags a runaway agent loop.
+
+## Running locally
+
+Assumes the sibling workspace layout (`../browser` next to this repo), or set
+`LPD_PATH` to any lightpanda binary (same variable wptrunner uses). Needs Go,
+`jq`, `curl`.
+
+```bash
+./agent/run.sh                    # all layers (live skipped if no key)
+./agent/run.sh deterministic
+GEMINI_API_KEY=... ./agent/run.sh live
+
+# from the browser repo:
+make test-agent                   # wraps this script, builds lightpanda if needed
+```
+
+Environment knobs (see the header of `run.sh`): `LPD_PATH`, `LP_MODEL`,
+`LP_HTTP_PROXY`, `MAX_TOKENS`.
+
+## CI
+
+Driven by the browser repo's CI, which checks this repo out and runs
+`agent/run.sh` — deterministic layer on every browser PR, all layers nightly /
+on demand. See that repo's workflows for the wiring; the contract is: pass the
+binary via `LPD_PATH`, a Gemini key via `GEMINI_API_KEY` for the live layer,
+and optionally a residential proxy via `LP_HTTP_PROXY` for the live HN call
+(datacenter IPs are often blocked by news.ycombinator.com).
+
+## Maintenance
+
+- **Add a deterministic case:** drop a `scripts/<name>.js` that returns a
+  value, then `./agent/run.sh update-golden` — every script in `scripts/` is
+  replayed and diffed automatically.
+- **Add a Q&A case:** append a `<task>\t<expected>` row to
+  `cases/static-qa.tsv` (point the task at any `public/` page with a
+  closed-form answer; avoid bare small numbers as expected substrings —
+  too weak as substring matches).
+- **Shared fixtures:** the goldens pin content of `public/campfire-commerce/`
+  and `public/amiibo/`. If those sites change for another suite, regenerate
+  with `./agent/run.sh update-golden` and review the diff — the golden is the
+  contract.
+- **Coupling note:** browser CI pins demo@main. A browser change that alters
+  extract/replay behavior needs a lockstep PR here to update the goldens.

--- a/agent/cases/hn-live.jq
+++ b/agent/cases/hn-live.jq
@@ -1,0 +1,24 @@
+# Invariant check for the live Hacker News agent output.
+#
+# The output contract lives in two co-located halves: cases/hn-live.task pins
+# what the agent must return, this file verifies it. Edit them together.
+#
+# We cannot assert exact values (live site + LLM both vary run to run), so we
+# assert the *shape*: a JSON array of exactly 5 stories, each with a non-empty
+# `title` string and a `comments` array of 0..3 objects, each comment having
+# non-empty `user` and `text` strings. A fresh story may legitimately have no
+# comments yet, but all 5 empty means extraction is broken — so at least one
+# story must have a comment.
+#
+# Evaluates to true iff every invariant holds. Use with `jq -e -f` so the
+# process exit code reflects the result.
+def nonempty_string: type == "string" and (length > 0);
+
+(type == "array")
+and (length == 5)
+and all(.[];
+      (.title | nonempty_string)
+  and (.comments | type == "array" and length <= 3)
+  and (.comments | all(.[]; (.user | nonempty_string) and (.text | nonempty_string)))
+)
+and any(.[]; .comments | length > 0)

--- a/agent/cases/hn-live.task
+++ b/agent/cases/hn-live.task
@@ -1,0 +1,1 @@
+Go to https://news.ycombinator.com, collect the top 5 stories and the top 3 comments of each story. Return a JSON array of exactly 5 objects, each with keys "title" (the story title string) and "comments" (an array of at most 3 objects, each with keys "user" and "text"; leave it empty if the story has no comments yet).

--- a/agent/cases/static-qa.tsv
+++ b/agent/cases/static-qa.tsv
@@ -1,0 +1,12 @@
+# Static Q&A regression cases for the live LLM layer, against the
+# campfire-commerce demo site (JS-rendered product page).
+# One case per line, TAB-separated: <task>\t<expected-substring>
+# The expected substring must appear (case-insensitive) in the agent's final
+# answer on stdout. Keep answers unambiguous so LLM phrasing does not matter —
+# match on the load-bearing token only, and avoid bare small numbers (too weak
+# as substrings).
+# Lines starting with # and blank lines are ignored.
+Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the price of the product on that page.	244.99
+Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the name of the product being sold.	Nomad Backpack
+Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the name of the cheapest related product listed on the page.	Water Bottle
+Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the price of the Outdoor Odyssey Hiking Poles shown in the related products.	79.99

--- a/agent/golden/amiibo.json
+++ b/agent/golden/amiibo.json
@@ -1,0 +1,24 @@
+{
+  "related": [
+    {
+      "game": "Animal Crossing",
+      "name": "Isabelle",
+      "serie": "Animal Crossing"
+    },
+    {
+      "game": "Animal Crossing",
+      "name": "Coach",
+      "serie": "Animal Crossing"
+    },
+    {
+      "game": "Mario Sports Superstars",
+      "name": "Boo - Soccer",
+      "serie": "Mario Sports Superstars"
+    }
+  ],
+  "start": {
+    "game": "Animal Crossing",
+    "name": "Sandy",
+    "serie": "Animal Crossing"
+  }
+}

--- a/agent/golden/campfire.json
+++ b/agent/golden/campfire.json
@@ -1,0 +1,35 @@
+{
+  "features": [
+    "Large 60-liter capacity for multi-day outdoor adventures",
+    "Padded shoulder straps and back panel for comfort and support",
+    "Multiple compartments and pockets, including a sleeping bag compartment and hydration bladder sleeve, for easy organization",
+    "Durable and water-resistant materials with compression straps and attachment points for trekking poles or ice axes for added functionality and convenience"
+  ],
+  "name": "Outdoor Odyssey Nomad Backpack 60 liters",
+  "price": "$244.99",
+  "related": [
+    {
+      "name": "Outdoor Odyssey Hiking Poles",
+      "price": "$79.99"
+    },
+    {
+      "name": "Outdoor Odyssey Sleeping Bag",
+      "price": "$129.99"
+    },
+    {
+      "name": "Outdoor Odyssey Water Bottle",
+      "price": "$19.99"
+    }
+  ],
+  "reviews": [
+    {
+      "title": "I recently took the Nomad..."
+    },
+    {
+      "title": "As an avid hiker, I've..."
+    },
+    {
+      "title": "I purchased the Nomad Backpack..."
+    }
+  ]
+}

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# Agent regression suite for `lightpanda agent`, driven by the browser repo's
+# CI (e2e-test.yml agent-deterministic job + agent-regression.yml). Two layers:
+#
+#   deterministic  — replay golden PandaScripts against the existing demo
+#                    sites in public/ (campfire-commerce, amiibo — both
+#                    JS-rendered, served by the demo runner) and compare the
+#                    returned JSON exactly to golden files. No API key, no
+#                    external network.
+#
+#   live           — drive the real LLM agent (needs an API key):
+#                      * static Q&A: ask closed-form questions about a local
+#                        fixture page, substring-match the answer.
+#                      * HN save+replay: ask the agent to scrape live Hacker
+#                        News and /save a reproducible script, then replay it
+#                        token-free and validate the output against a shape
+#                        invariant (jq), not exact values.
+#
+# Usage: agent/run.sh [deterministic|live|all|update-golden]  (default: all)
+#
+# update-golden regenerates every golden/<name>.json from the current sites
+# and scripts — review the diff before committing.
+#
+# Env:
+#   LPD_PATH       path to the lightpanda binary, same variable wptrunner uses
+#                  (default: ../browser/zig-out/bin/lightpanda, the sibling
+#                  workspace checkout; CI always sets it explicitly)
+#   GOOGLE_API_KEY or GEMINI_API_KEY (the binary accepts both) — required for
+#                  the live layer; live layer is skipped if neither is set
+#   LP_MODEL       Gemini model id for the live layer (default below)
+#   LP_HTTP_PROXY  optional proxy for the live HN call only (datacenter IPs are
+#                  often blocked by news.ycombinator.com); localhost fixtures
+#                  are never proxied
+#   MAX_TOKENS     per-live-task total-token ceiling (default: 3000000).
+#                  `total` counts cached reads, so a normal HN save is ~1M;
+#                  this is a loose backstop against a runaway agent loop.
+set -uo pipefail
+
+LAYER="${1:-all}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO="$(cd "$HERE/.." && pwd)"
+LPD="${LPD_PATH:-$DEMO/../browser/zig-out/bin/lightpanda}"
+# Pin an explicit model id — never a *-latest / *-preview alias, which drift.
+LP_MODEL="${LP_MODEL:-gemini-3.5-flash}"
+MAX_TOKENS="${MAX_TOKENS:-3000000}"
+
+export LIGHTPANDA_DISABLE_TELEMETRY=true
+
+PASS=0
+FAIL=0
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+pass()  { green "PASS: $1"; PASS=$((PASS + 1)); }
+fail()  { red   "FAIL: $1"; FAIL=$((FAIL + 1)); }
+info()  { printf '\033[2m%s\033[0m\n' "$1"; }
+
+[ -x "$LPD" ] || { red "lightpanda binary not found or not executable: $LPD"; exit 2; }
+
+TMP="$(mktemp -d)"
+SRV=""
+cleanup() {
+  [ -n "$SRV" ] && kill "$SRV" 2>/dev/null
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# The address is not configurable: the site URLs are pinned in scripts/*.js,
+# the goldens, and cases/static-qa.tsv. An already-running server (e.g. a
+# shared `runner -serve` in CI) is adopted instead of started — and then not
+# killed on exit.
+start_server() {
+  local probe="http://127.0.0.1:1234/campfire-commerce/json/product.json"
+  if curl -sf "$probe" -o /dev/null; then
+    info "reusing fixture server already running on 127.0.0.1:1234"
+    return 0
+  fi
+  # Build instead of `go run` so kill reaches the server process itself, not
+  # a parent that may orphan it. Pass the address/dir flags so stray
+  # RUNNER_HTTP_* env vars can't move the server away from the pinned URLs.
+  ( cd "$DEMO/runner" && go build -o "$TMP/runner" . ) || { red "runner build failed"; exit 2; }
+  "$TMP/runner" -serve -http-addr 127.0.0.1:1234 -http-dir "$DEMO/public" >/dev/null 2>&1 &
+  SRV=$!
+  for _ in $(seq 1 25); do
+    curl -sf "$probe" -o /dev/null && return 0
+    kill -0 "$SRV" 2>/dev/null || break
+    sleep 0.2
+  done
+  red "fixture server failed to start on 127.0.0.1:1234"; exit 2
+}
+
+# --- deterministic layer -----------------------------------------------------
+run_replay() {
+  local name="$1"
+  if ! "$LPD" agent "$HERE/scripts/$name.js" >"$TMP/out" 2>/dev/null; then
+    fail "$name.js replay (non-zero exit)"; return
+  fi
+  if ! jq -e . "$TMP/out" >/dev/null 2>&1; then
+    fail "$name.js replay (output is not valid JSON)"; return
+  fi
+  local d
+  if d="$(diff <(jq -S . "$HERE/golden/$name.json") <(jq -S . "$TMP/out"))"; then
+    pass "$name.js replay matches golden"
+  else
+    fail "$name.js replay differs from golden/$name.json"
+    info "  diff (golden < , actual > ):"
+    printf '%s\n' "$d" | sed 's/^/    /'
+    info "  if public/ changed intentionally, regenerate with agent/run.sh update-golden; otherwise this is an extract/replay regression"
+  fi
+}
+
+run_deterministic() {
+  info "== deterministic layer (no API key) =="
+  local s
+  for s in "$HERE"/scripts/*.js; do
+    run_replay "$(basename "$s" .js)"
+  done
+}
+
+# An instant empty answer usually means an API error (bad key, quota) that
+# only appears on stderr.
+show_err() {
+  sed -n '/^\$usage /!p' "$1" | tail -3 | sed 's/^/    /'
+}
+
+# The $usage stderr line is a stable key=value contract for wrappers; the
+# ceiling is a backstop against runaway agent loops.
+check_usage() {
+  local errfile="$1" label="$2" total
+  total="$(sed -n '/^\$usage /{s/.*total=\([0-9]\+\).*/\1/p;q}' "$errfile")"
+  [ -n "$total" ] && info "  usage: total=${total} tokens ($label)"
+  if [ -n "$total" ] && [ "$total" -gt "$MAX_TOKENS" ]; then
+    fail "$label exceeded token ceiling ($total > $MAX_TOKENS)"
+  fi
+}
+
+# --- live layer --------------------------------------------------------------
+run_live_qa() {
+  info "== live layer: static Q&A (model=$LP_MODEL) =="
+  while IFS=$'\t' read -r task expected; do
+    [ -z "${task// }" ] && continue
+    case "$task" in \#*) continue ;; esac
+    timeout 300 "$LPD" agent --provider gemini --model "$LP_MODEL" --task "$task" >"$TMP/out" 2>"$TMP/err"
+    if grep -qiF "$expected" "$TMP/out"; then
+      pass "Q&A: expected \"$expected\""
+    else
+      fail "Q&A: expected \"$expected\" not found in answer"
+      info "  answer: $(tr '\n' ' ' <"$TMP/out" | cut -c1-200)"
+      show_err "$TMP/err"
+    fi
+    check_usage "$TMP/err" "Q&A \"$expected\""
+  done <"$HERE/cases/static-qa.tsv"
+}
+
+run_live_hn() {
+  info "== live layer: HN save + replay (model=$LP_MODEL) =="
+  local script="$TMP/hn-live.js" task
+  task="$(cat "$HERE/cases/hn-live.task")"
+
+  local proxy_args=()
+  [ -n "${LP_HTTP_PROXY:-}" ] && proxy_args=(--http-proxy "$LP_HTTP_PROXY")
+
+  timeout 900 "$LPD" agent --provider gemini --model "$LP_MODEL" "${proxy_args[@]}" --task "$task" --save "$script" >/dev/null 2>"$TMP/err"
+  check_usage "$TMP/err" "HN save"
+
+  if [ ! -s "$script" ]; then
+    fail "HN save produced no script"
+    show_err "$TMP/err"
+    return
+  fi
+  if grep -q 'goto(' "$script" && grep -q 'extract(' "$script"; then
+    pass "HN saved script looks replayable (has goto + extract)"
+  else
+    fail "HN saved script missing goto/extract — see below"
+    sed 's/^/    /' "$script"
+  fi
+
+  # Replay without --task runs no LLM — no key or tokens needed.
+  if ! timeout 300 "$LPD" agent "$script" >"$TMP/out" 2>/dev/null; then
+    fail "HN saved script failed on replay"; return
+  fi
+  if jq -e -f "$HERE/cases/hn-live.jq" "$TMP/out" >/dev/null 2>&1; then
+    pass "HN replay output satisfies shape invariant"
+  else
+    fail "HN replay output violates cases/hn-live.jq"
+    info "  output: $(tr '\n' ' ' <"$TMP/out" | cut -c1-300)"
+  fi
+}
+
+# --- dispatch ----------------------------------------------------------------
+start_server
+
+case "$LAYER" in
+  deterministic) run_deterministic ;;
+  live)
+    [ -n "${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}" ] || { red "GOOGLE_API_KEY/GEMINI_API_KEY unset — cannot run live layer"; exit 2; }
+    run_live_qa; run_live_hn ;;
+  all)
+    run_deterministic
+    if [ -n "${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}" ]; then
+      run_live_qa; run_live_hn
+    else
+      info "GOOGLE_API_KEY/GEMINI_API_KEY unset — skipping live layer"
+    fi ;;
+  update-golden)
+    for s in "$HERE"/scripts/*.js; do
+      name="$(basename "$s" .js)"
+      "$LPD" agent "$s" 2>/dev/null | jq -S . >"$HERE/golden/$name.json"
+      info "golden/$name.json regenerated"
+    done
+    info "review the diff before committing"
+    exit 0 ;;
+  *) red "unknown layer: $LAYER (use deterministic|live|all|update-golden)"; exit 2 ;;
+esac
+
+echo
+echo "-------------------------------------"
+if [ "$FAIL" -eq 0 ]; then
+  green "SUMMARY: $PASS passed, 0 failed"
+  exit 0
+else
+  red "SUMMARY: $PASS passed, $FAIL failed"
+  exit 1
+fi

--- a/agent/scripts/amiibo.js
+++ b/agent/scripts/amiibo.js
@@ -1,0 +1,33 @@
+// Keep in sync with golden/amiibo.json. Each amiibo page is a JS-rendered
+// shell (load.js fills it from JSON), hence the networkidle waits.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/amiibo/index.html");
+page.waitForState("networkidle");
+
+const { alt, ...start } = page.extract({
+  name: "#name",
+  game: "#game",
+  serie: "#serie",
+  alt: [{
+    selector: "#alt li a",
+    limit: 3,
+    fields: {
+      href: { selector: "", attr: "href" }
+    }
+  }]
+});
+
+const related = [];
+for (const link of alt) {
+  // extract resolves href attributes to absolute URLs.
+  await page.goto(link.href);
+  page.waitForState("networkidle");
+  const character = page.extract({
+    name: "#name",
+    game: "#game",
+    serie: "#serie"
+  });
+  related.push(character);
+}
+
+return { start, related };

--- a/agent/scripts/campfire.js
+++ b/agent/scripts/campfire.js
@@ -1,0 +1,26 @@
+// Keep in sync with golden/campfire.json.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/campfire-commerce/");
+// The page renders from two separate fetches (product.json, reviews.json);
+// extracting before both complete reads the empty shell.
+page.waitForSelector("#product-related .col-3");
+page.waitForSelector("#product-reviews .col-3");
+
+return page.extract({
+  name: "#product-name",
+  price: "#product-price",
+  features: ["#product-features li"],
+  related: [{
+    selector: "#product-related .col-3",
+    fields: {
+      name: "h4",
+      price: "p"
+    }
+  }],
+  reviews: [{
+    selector: "#product-reviews .col-3",
+    fields: {
+      title: "h4"
+    }
+  }]
+});


### PR DESCRIPTION
Adds a `lightpanda agent` regression suite that runs against the **existing demo sites** in `public/` — no new fixture pages. The browser repo's CI checks demo out and drives it, same as runner/integration/wpt.

## What's in it

Two layers driven by `agent/run.sh` (details in `agent/README.md`):

- **deterministic** — replays golden PandaScripts and diffs the returned JSON exactly against `agent/golden/`:
  - `campfire.js`: single-page extract of campfire-commerce (name, price, features, related, reviews)
  - `amiibo.js`: front page → item pages crawl via the "See also" links

  Both sites are JS-rendered shells (scripts fetch JSON and fill the DOM), so this layer exercises script execution, `fetch`, and DOM manipulation on top of navigation/extraction. No API key, no external network.
- **live** (`GOOGLE_API_KEY`/`GEMINI_API_KEY`) — closed-form Q&A over campfire-commerce (substring match), plus a live Hacker News scrape saved via `--save`, replayed token-free and validated against a jq **shape** invariant (`agent/schemas/hn-live.jq`; the prompt in `agent/cases/hn-live.task` pins the contract).

The suite reuses the existing runner static server (`runner -serve`, `public/` on `:1234`) — run.sh builds and starts it itself. Goldens regenerate with `./agent/run.sh update-golden`.

## How it's consumed

The `agent-deterministic` job in the browser repo's `e2e-test.yml` (every browser PR) and `agent-regression.yml` (nightly + `workflow_dispatch`) download the built binary and pass it via `LPD`. A follow-up browser PR switches those jobs from the in-repo copy to this checkout.

## Validation (local, against the built browser binary)

- `./agent/run.sh deterministic` — 2/2 PASS; broken-selector negative case fails as expected; `update-golden` round-trips with zero diff; goldens stable across repeated runs.
- `GEMINI_API_KEY=... ./agent/run.sh live` — 6/6 PASS (Q&A ×4, HN save replayable, shape invariant).
- The same two-layer suite already ran green end-to-end in browser CI pre-move: lightpanda-io/browser actions run 28576642458.

## Lockstep note

Until the follow-up browser PR lands, the browser repo still carries the old in-repo copy of this suite (`test/agent/`, wired to `make test-agent` and both workflows). That PR deletes it and repoints the workflows/Makefile at this checkout (passing the binary via `LPD_PATH`, the same variable wptrunner uses) — merge this first, then that one.
