### PR TITLE
agent: extend regression coverage to interaction tools

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,7 +1,9 @@
 # Agent regression suite
 
 End-to-end regression tests for `lightpanda agent`, running against the demo
-sites that already live in `public/` — no dedicated fixtures. The **browser
+sites that already live in `public/`. One fixture exists for this suite
+specifically (`public/form/checkbox.html` — nothing else in `public/` has a
+checkable input for `setChecked` to target); everything else is shared. The **browser
 repo's CI** checks demo out and drives this suite, the same way the
 runner/integration/wpt suites work. Two layers, so the cheap deterministic
 checks can gate every browser PR while the expensive keyed checks run
@@ -12,8 +14,16 @@ agent/
   run.sh                 orchestrator (bash + jq + the demo runner server)
   scripts/campfire.js    golden PandaScript: campfire-commerce product page
   scripts/amiibo.js      golden PandaScript: amiibo front page -> item crawl
+  scripts/form.js        golden PandaScript: fill/selectOption/click + submit echo
+  scripts/checked.js     golden PandaScript: setChecked on checkbox/radio + event order
+  scripts/magic8ball.js  golden PandaScript: iframe + postMessage + Web Worker
+  scripts/redirects.js   golden PandaScript: 3-hop location-write redirect chain
+  scripts/cookies.js     golden PandaScript: cookie jar via fetch/XHR/302
+  scripts/dynamic.js     golden PandaScript: injected <script> + cross-frame read
   golden/<name>.json     exact expected replay output per script
   cases/static-qa.tsv    <task>\t<expected-substring> per line
+  cases/form-live.task   task prompt for the local form save+replay case
+  cases/form-live.jq     invariant verifying that contract (pinned values)
   cases/hn-live.task     task prompt for the live HN case (pins the contract)
   cases/hn-live.jq       shape invariant verifying that contract
 ```
@@ -36,15 +46,42 @@ against its `golden/<name>.json`:
   related products, and reviews (waits on the two async renders).
 - `amiibo.js` — front page → item pages crawl via the "See also" links, the
   same shape as the live Hacker News case.
+- `form.js` — fill/selectOption/click against `public/form/`, submitting to
+  the runner's `/form/submit` echo: GET query encoding, hidden-field
+  inclusion, disabled-field exclusion, and submitter-button semantics on a
+  POST body.
+- `checked.js` — `setChecked` against `public/form/checkbox.html`: unchecking
+  a pre-checked box drops it from the submission, checking adds it, picking a
+  radio replaces the group's value, and a listener-recorded field pins the
+  click → input → change dispatch order (each fired exactly once).
+- `magic8ball.js` — fill + click, then the answer travels window → iframe
+  (postMessage) → Web Worker → back; `waitForScript` synchronizes and the
+  script normalizes the random answer into a membership check.
+- `redirects.js` — `public/location_write/` chain (`location.assign`,
+  `document.location =`, `top.location =`); replay must settle on the final
+  document.
+- `cookies.js` — cookies set by a plain response and by a 302, then read back
+  through `fetch` and `XMLHttpRequest` via the runner's `/cookies/get` echo.
+- `dynamic.js` — a `<script>` element appended at runtime must load before
+  extraction; plus a cross-frame DOM read (`public/frames/`).
 
 ### Live (needs `GOOGLE_API_KEY` or `GEMINI_API_KEY`, nightly / on demand)
 
 Drives the real Gemini-backed agent:
 
 - **Static Q&A** — for each row in `cases/static-qa.tsv`, run
-  `lightpanda agent --task "<question about campfire-commerce>"` and assert
+  `lightpanda agent --task "<question about a public/ fixture>"` and assert
   the expected substring appears in the answer. Closed-form answers make the
-  substring match robust to LLM phrasing.
+  substring match robust to LLM phrasing. Rows include interaction-forcing
+  tasks (fill + submit a form and report the echoed query) so the live agent
+  is exercised beyond read/extract.
+- **Form save + replay** — ask the agent (task in `cases/form-live.task`) to
+  fill and submit the local form fixture and `/save` the script, then replay
+  it token-free and validate against `cases/form-live.jq`. The fixture is
+  deterministic, so the invariant pins actual values, and the saved script is
+  checked for recorded interaction calls (`fill` + `click`/`press`) — the only
+  e2e coverage that the Recorder captures interactions. Runs whenever a key is
+  present; no proxy or external network needed.
 - **HN save + replay** — ask the agent (task in `cases/hn-live.task`) to
   scrape live Hacker News and `/save` a reproducible script, then replay that
   script **token-free** and validate the output against `cases/hn-live.jq`

--- a/agent/cases/form-live.jq
+++ b/agent/cases/form-live.jq
@@ -1,0 +1,20 @@
+# Invariant check for the live form save+replay output.
+#
+# The output contract lives in two co-located halves: cases/form-live.task
+# pins what the agent must return, this file verifies it. Edit them together.
+#
+# Unlike hn-live, the fixture is fully deterministic — only the LLM side
+# varies (how it phrases the extraction, whether it clicks or presses Enter) —
+# so the values themselves are pinned: a GET submission whose query string
+# carries the typed h3 value and the form's hidden h1 field, and never the
+# disabled h2 field.
+#
+# Evaluates to true iff every invariant holds. Use with `jq -e -f` so the
+# process exit code reflects the result.
+(type == "object")
+and (.method | type == "string" and ascii_upcase == "GET")
+and (.query | type == "string"
+  and contains("h3=lightpanda42")
+  and contains("h1=v1")
+  and (contains("h2=") | not)
+)

--- a/agent/cases/form-live.task
+++ b/agent/cases/form-live.task
@@ -1,0 +1,1 @@
+Go to http://127.0.0.1:1234/form/get.html, type "lightpanda42" into the text input whose name is h3, then submit the form. The server echoes the request back. Return a JSON object with keys "method" (the echoed HTTP method string) and "query" (the echoed query string).

--- a/agent/cases/static-qa.tsv
+++ b/agent/cases/static-qa.tsv
@@ -10,3 +10,5 @@ Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the price of the prod
 Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the name of the product being sold.	Nomad Backpack
 Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the name of the cheapest related product listed on the page.	Water Bottle
 Go to http://127.0.0.1:1234/campfire-commerce/ and tell me the price of the Outdoor Odyssey Hiking Poles shown in the related products.	79.99
+Go to http://127.0.0.1:1234/form/get.html, type "panda42" into the text input whose name is h3, submit the form, and tell me the query string the server echoed back.	h3=panda42
+Go to http://127.0.0.1:1234/amiibo/index.html and tell me the name of the amiibo character shown on that page.	Sandy

--- a/agent/golden/checked.json
+++ b/agent/golden/checked.json
@@ -1,0 +1,4 @@
+{
+  "method": "GET",
+  "query": "promo=daily&plan=pro&events=click-input-change"
+}

--- a/agent/golden/cookies.json
+++ b/agent/golden/cookies.json
@@ -1,0 +1,70 @@
+{
+  "fetch": [
+    {
+      "Domain": "",
+      "Expires": "0001-01-01T00:00:00Z",
+      "HttpOnly": false,
+      "MaxAge": 0,
+      "Name": "lightpanda",
+      "Partitioned": false,
+      "Path": "",
+      "Quoted": false,
+      "Raw": "",
+      "RawExpires": "",
+      "SameSite": 0,
+      "Secure": false,
+      "Unparsed": null,
+      "Value": "browser"
+    },
+    {
+      "Domain": "",
+      "Expires": "0001-01-01T00:00:00Z",
+      "HttpOnly": false,
+      "MaxAge": 0,
+      "Name": "redirect",
+      "Partitioned": false,
+      "Path": "",
+      "Quoted": false,
+      "Raw": "",
+      "RawExpires": "",
+      "SameSite": 0,
+      "Secure": false,
+      "Unparsed": null,
+      "Value": "cookie"
+    }
+  ],
+  "xhr": [
+    {
+      "Domain": "",
+      "Expires": "0001-01-01T00:00:00Z",
+      "HttpOnly": false,
+      "MaxAge": 0,
+      "Name": "lightpanda",
+      "Partitioned": false,
+      "Path": "",
+      "Quoted": false,
+      "Raw": "",
+      "RawExpires": "",
+      "SameSite": 0,
+      "Secure": false,
+      "Unparsed": null,
+      "Value": "browser"
+    },
+    {
+      "Domain": "",
+      "Expires": "0001-01-01T00:00:00Z",
+      "HttpOnly": false,
+      "MaxAge": 0,
+      "Name": "redirect",
+      "Partitioned": false,
+      "Path": "",
+      "Quoted": false,
+      "Raw": "",
+      "RawExpires": "",
+      "SameSite": 0,
+      "Secure": false,
+      "Unparsed": null,
+      "Value": "cookie"
+    }
+  ]
+}

--- a/agent/golden/dynamic.json
+++ b/agent/golden/dynamic.json
@@ -1,0 +1,4 @@
+{
+  "frame": "<p>over 9000!</p>\n",
+  "product": "Keemun"
+}

--- a/agent/golden/form.json
+++ b/agent/golden/form.json
@@ -1,0 +1,11 @@
+{
+  "get": {
+    "method": "GET",
+    "query": "h1=v1&h3=panda&favorite+drink=tea&ta=hello"
+  },
+  "post": {
+    "body": "h1=v1&h3=v3&favorite+drink=tea&s1=go",
+    "method": "POST",
+    "query": ""
+  }
+}

--- a/agent/golden/magic8ball.json
+++ b/agent/golden/magic8ball.json
@@ -1,0 +1,4 @@
+{
+  "answered": true,
+  "oracle": true
+}

--- a/agent/golden/redirects.json
+++ b/agent/golden/redirects.json
@@ -1,0 +1,4 @@
+{
+  "page": "4",
+  "path": "/location_write/index4.html"
+}

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -12,6 +12,11 @@
 #   live           — drive the real LLM agent (needs an API key):
 #                      * static Q&A: ask closed-form questions about a local
 #                        fixture page, substring-match the answer.
+#                      * form save+replay: ask the agent to fill and submit a
+#                        local form fixture and /save the script, then replay
+#                        it token-free — the only e2e check that the Recorder
+#                        emits interaction calls (fill/click), not just
+#                        goto/extract.
 #                      * HN save+replay: ask the agent to scrape live Hacker
 #                        News and /save a reproducible script, then replay it
 #                        token-free and validate the output against a shape
@@ -153,39 +158,59 @@ run_live_qa() {
   done <"$HERE/cases/static-qa.tsv"
 }
 
-run_live_hn() {
-  info "== live layer: HN save + replay (model=$LP_MODEL) =="
-  local script="$TMP/hn-live.js" task
-  task="$(cat "$HERE/cases/hn-live.task")"
+# Save + replay flow shared by the live cases: run the agent with the task
+# from cases/<name>.task and --save, require every space-separated regex in
+# <required-calls> to match the saved script, then replay it token-free and
+# validate the output with cases/<name>.jq. Extra args go to the save run
+# (e.g. --http-proxy).
+run_live_save_replay() {
+  local name="$1" save_timeout="$2" replay_timeout="$3" required="$4"
+  shift 4
+  local script="$TMP/$name.js" task
+  task="$(cat "$HERE/cases/$name.task")"
 
-  local proxy_args=()
-  [ -n "${LP_HTTP_PROXY:-}" ] && proxy_args=(--http-proxy "$LP_HTTP_PROXY")
-
-  timeout 900 "$LPD" agent --provider gemini --model "$LP_MODEL" "${proxy_args[@]}" --task "$task" --save "$script" >/dev/null 2>"$TMP/err"
-  check_usage "$TMP/err" "HN save"
+  timeout "$save_timeout" "$LPD" agent --provider gemini --model "$LP_MODEL" "$@" --task "$task" --save "$script" >/dev/null 2>"$TMP/err"
+  check_usage "$TMP/err" "$name save"
 
   if [ ! -s "$script" ]; then
-    fail "HN save produced no script"
+    fail "$name save produced no script"
     show_err "$TMP/err"
     return
   fi
-  if grep -q 'goto(' "$script" && grep -q 'extract(' "$script"; then
-    pass "HN saved script looks replayable (has goto + extract)"
+  local p missing=""
+  for p in $required; do
+    grep -qE "$p" "$script" || missing="$missing $p"
+  done
+  if [ -z "$missing" ]; then
+    pass "$name saved script records the expected calls ($required)"
   else
-    fail "HN saved script missing goto/extract — see below"
+    fail "$name saved script missing$missing — see below"
     sed 's/^/    /' "$script"
   fi
 
   # Replay without --task runs no LLM — no key or tokens needed.
-  if ! timeout 300 "$LPD" agent "$script" >"$TMP/out" 2>/dev/null; then
-    fail "HN saved script failed on replay"; return
+  if ! timeout "$replay_timeout" "$LPD" agent "$script" >"$TMP/out" 2>/dev/null; then
+    fail "$name saved script failed on replay"; return
   fi
-  if jq -e -f "$HERE/cases/hn-live.jq" "$TMP/out" >/dev/null 2>&1; then
-    pass "HN replay output satisfies shape invariant"
+  if jq -e -f "$HERE/cases/$name.jq" "$TMP/out" >/dev/null 2>&1; then
+    pass "$name replay output satisfies cases/$name.jq"
   else
-    fail "HN replay output violates cases/hn-live.jq"
+    fail "$name replay output violates cases/$name.jq"
     info "  output: $(tr '\n' ' ' <"$TMP/out" | cut -c1-300)"
   fi
+}
+
+run_live_hn() {
+  info "== live layer: HN save + replay (model=$LP_MODEL) =="
+  local proxy_args=()
+  [ -n "${LP_HTTP_PROXY:-}" ] && proxy_args=(--http-proxy "$LP_HTTP_PROXY")
+  run_live_save_replay hn-live 900 300 'goto\( extract\(' "${proxy_args[@]}"
+}
+
+run_live_form_save() {
+  info "== live layer: form save + replay (model=$LP_MODEL) =="
+  # The agent may submit via click or by pressing Enter — accept either.
+  run_live_save_replay form-live 300 120 'fill\( click\(|press\('
 }
 
 # --- dispatch ----------------------------------------------------------------
@@ -195,11 +220,11 @@ case "$LAYER" in
   deterministic) run_deterministic ;;
   live)
     [ -n "${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}" ] || { red "GOOGLE_API_KEY/GEMINI_API_KEY unset — cannot run live layer"; exit 2; }
-    run_live_qa; run_live_hn ;;
+    run_live_qa; run_live_form_save; run_live_hn ;;
   all)
     run_deterministic
     if [ -n "${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}" ]; then
-      run_live_qa; run_live_hn
+      run_live_qa; run_live_form_save; run_live_hn
     else
       info "GOOGLE_API_KEY/GEMINI_API_KEY unset — skipping live layer"
     fi ;;

--- a/agent/scripts/checked.js
+++ b/agent/scripts/checked.js
@@ -1,0 +1,14 @@
+// Keep in sync with golden/checked.json. The fixture records the event order
+// on #promo into the submitted `events` field, pinning click -> input -> change.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/form/checkbox.html");
+page.setChecked("#news", false);
+page.setChecked("#promo", true);
+page.setChecked("#pro", true);
+page.click("#submit");
+page.waitForSelector("#method");
+
+return page.extract({
+  method: "#method",
+  query: "#query"
+});

--- a/agent/scripts/cookies.js
+++ b/agent/scripts/cookies.js
@@ -1,0 +1,17 @@
+// Keep in sync with golden/cookies.json. The runner sets cookies via a plain
+// response (/cookies/set) and via a 302 (/cookies/redirect); the fixture pages
+// then fetch/XHR /cookies/get, which echoes the request cookies as JSON into
+// #result.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/cookies/set");
+await page.goto("http://127.0.0.1:1234/cookies/redirect");
+
+await page.goto("http://127.0.0.1:1234/cookies/fetch.html");
+page.waitForScript("document.getElementById('result').textContent.trim().length > 0");
+const viaFetch = page.extract({ cookies: "#result" }).cookies;
+
+await page.goto("http://127.0.0.1:1234/cookies/xhr.html");
+page.waitForScript("document.getElementById('result').textContent.trim().length > 0");
+const viaXhr = page.extract({ cookies: "#result" }).cookies;
+
+return { fetch: JSON.parse(viaFetch), xhr: JSON.parse(viaXhr) };

--- a/agent/scripts/dynamic.js
+++ b/agent/scripts/dynamic.js
@@ -1,0 +1,12 @@
+// Keep in sync with golden/dynamic.json. The appended <script> must load and
+// run before extraction; frames/index.html reads the child frame's DOM onload.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/dynamic_scripts/index.html");
+page.waitForScript("document.getElementById('product').textContent.length > 0");
+const product = page.extract({ product: "#product" }).product;
+
+await page.goto("http://127.0.0.1:1234/frames/index.html");
+page.waitForScript("typeof window.frame1_content === 'string'");
+const frame = page.evaluate("window.frame1_content");
+
+return { product, frame };

--- a/agent/scripts/form.js
+++ b/agent/scripts/form.js
@@ -1,0 +1,27 @@
+// Keep in sync with golden/form.json. The runner's /form/submit echoes the
+// method, body, and query string back as HTML.
+const page = new Page();
+
+// Hidden h1 is included in the echoed query, disabled h2 excluded.
+await page.goto("http://127.0.0.1:1234/form/get.html");
+page.fill("#input", "panda");
+page.fill("#ta", "hello");
+page.selectOption("select[name='favorite drink']", "tea");
+page.click("#submit");
+page.waitForSelector("#method");
+const get = page.extract({
+  method: "#method",
+  query: "#query"
+});
+
+// Submitter semantics: clicking s1 puts s1=go in the POST body, excludes s2.
+await page.goto("http://127.0.0.1:1234/form/submit_button.html");
+page.click("input[name=s1]");
+page.waitForSelector("#method");
+const post = page.extract({
+  method: "#method",
+  body: "#body",
+  query: "#query"
+});
+
+return { get, post };

--- a/agent/scripts/magic8ball.js
+++ b/agent/scripts/magic8ball.js
@@ -1,0 +1,28 @@
+// Keep in sync with golden/magic8ball.json. The answer travels
+// window -> iframe (postMessage) -> Web Worker -> back. The worker picks
+// its answer with Math.random(), so the script normalizes it to a membership
+// check instead of pinning the text. Waits are expression-based, not
+// networkidle: the page references an external Wikimedia image.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/magic8ball/index.html");
+
+page.fill("#question", "Will this replay deterministically?");
+page.click("#ask-form button[type=submit]");
+page.waitForScript(
+  "!['ask me anything', '...'].includes(document.getElementById('answer').textContent)"
+);
+
+const known = page.evaluate(`[
+  'It is certain.', 'Without a doubt.', 'Most likely.', 'Outlook good.',
+  'Yes, definitely.', 'Signs point to yes.', 'Reply hazy, try again.',
+  'Ask again later.', 'Cannot predict now.', "Don't count on it.",
+  'My reply is no.', 'Very doubtful.', 'Outlook not so good.',
+  'Concentrate and ask again.', 'Absolutely not.', 'The stars say yes.'
+].includes(document.getElementById('answer').textContent)`);
+
+const oracle = page.evaluate(
+  "document.querySelector('#child').contentDocument.getElementById('state').textContent.startsWith('the spirits whisper: ')"
+);
+
+// evaluate returns strings; normalize so the golden pins real booleans.
+return { answered: known === "true", oracle: oracle === "true" };

--- a/agent/scripts/redirects.js
+++ b/agent/scripts/redirects.js
@@ -1,0 +1,13 @@
+// Keep in sync with golden/redirects.json. index1 -> index4 is a three-hop
+// script-driven redirect chain (location.assign, document.location =,
+// top.location =); the replay must settle on the final document.
+const page = new Page();
+await page.goto("http://127.0.0.1:1234/location_write/index1.html");
+page.waitForScript(
+  "document.getElementById('page') && document.getElementById('page').textContent === '4'"
+);
+
+return {
+  page: page.extract({ page: "#page" }).page,
+  path: page.evaluate("location.pathname")
+};

--- a/public/form/checkbox.html
+++ b/public/form/checkbox.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<body>
+<form id=f action=submit>
+  <input type=checkbox id=news name=news value=weekly checked>
+  <input type=checkbox id=promo name=promo value=daily>
+  <input type=radio id=free name=plan value=free checked>
+  <input type=radio id=pro name=plan value=pro>
+  <input type=hidden id=events name=events>
+  <input id=submit type=submit>
+</form>
+<script>
+// Record the event order on #promo into a submitted field, so the /form/submit
+// echo pins that toggling dispatches click, then input, then change.
+for (const type of ['click', 'input', 'change']) {
+  document.getElementById('promo').addEventListener(type, () => {
+    const events = document.getElementById('events');
+    events.value = events.value ? events.value + '-' + type : type;
+  });
+}
+</script>
+</body>


### PR DESCRIPTION
Extends the agent regression suite with the coverage gaps found by auditing the recorded-tool surface: no interaction tool (`click`, `fill`, `press`, `selectOption`, `setChecked`) had any e2e coverage, and the Recorder had never been e2e-tested on interaction calls.

## Deterministic layer (6 new golden scripts, gate every browser PR)

All reuse sites `public/` already serves plus the runner's existing echo endpoints; one new fixture was needed:

- **form.js** — fill/selectOption/click through the `/form/submit` echo: GET query encoding, hidden-field inclusion, disabled-field exclusion, submitter-button semantics on a POST body.
- **checked.js** — `setChecked` against the new `public/form/checkbox.html` (nothing else in `public/` has a checkable input): uncheck-drops-field, check-adds-field, radio replacement, and the `click → input → change` dispatch order pinned via a listener-recorded field.
- **magic8ball.js** — fill + click, answer travels window → iframe (postMessage) → Web Worker → back; the random answer is normalized to a membership check so the golden stays exact.
- **redirects.js** — 3-hop location-write redirect chain (`location.assign`, `document.location =`, `top.location =`) settles on the final document.
- **cookies.js** — cookies set by a plain response and by a 302, read back through both `fetch` and `XMLHttpRequest`.
- **dynamic.js** — runtime-appended `<script>` loads before extraction, plus a cross-frame DOM read.

All eight replays (including the two pre-existing) pass and were verified byte-identical across repeated runs.

## Live layer

- Two interaction-forcing static-QA rows (fill + submit a form and report the echoed query; amiibo front-page fact).
- A local **form save+replay** case — the first e2e check that the Recorder emits interaction calls (`fill` + `click`/`press`). The fixture is deterministic so `cases/form-live.jq` pins actual values; no proxy or external network needed. It shares a new `run_live_save_replay` helper with the HN case (they were near-copies otherwise).

Verified against the real Gemini agent: both new QA rows and the save+replay flow pass.

## ⚠️ Merge order

`checked.js` pins the **fixed** `setChecked` behavior. Browser `main` currently double-toggles checkboxes (the state-then-click sequence is undone by click activation) — this suite caught that bug. Merge lightpanda-io/browser#2874 (contains the fix) **before** this PR, or every browser PR's `agent-deterministic` job will fail on `checked.js`.