### PR TITLE
RequestInterception redirect tests.

### DIFF
--- a/chromedp/ri_redirect/main.go
+++ b/chromedp/ri_redirect/main.go
@@ -1,0 +1,240 @@
+// Copyright 2023-2026 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// chromedp variant of playwright/cdp_session_redirect.js, driving Fetch
+// interception through the driver's own (primary) target session. Navigates
+// through /redirect/headers -> /get/headers (302) and asserts that both hops
+// are paused with fresh requestIds and a stable networkId, and that a header
+// override applied to the initial request does not survive the redirect.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/chromedp"
+)
+
+const (
+	exitOK   = 0
+	exitFail = 1
+)
+
+// main starts interruptable context and runs the program.
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := run(ctx, os.Args, os.Stdout, os.Stderr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(exitFail)
+	}
+
+	os.Exit(exitOK)
+}
+
+const (
+	CdpWSDefault = "ws://127.0.0.1:9222"
+)
+
+type pause struct {
+	requestID string
+	networkID string
+	url       string
+	headers   map[string]string
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	// declare runtime flag parameters.
+	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
+	flags.SetOutput(stderr)
+
+	var (
+		verbose = flags.Bool("verbose", false, "enable debug log level")
+		cdpws   = flags.String("cdp", env("CDPCLI_WS", CdpWSDefault), "cdp ws to connect")
+	)
+
+	// usage func declaration.
+	exec := args[0]
+	flags.Usage = func() {
+		fmt.Fprintf(stderr, "usage: %s <base url>\n", exec)
+		fmt.Fprintf(stderr, "chromedp request interception through a redirect.\n")
+		fmt.Fprintf(stderr, "\nCommand line options:\n")
+		flags.PrintDefaults()
+		fmt.Fprintf(stderr, "\nEnvironment vars:\n")
+		fmt.Fprintf(stderr, "\tCDPCLI_WS\tdefault %s\n", CdpWSDefault)
+	}
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
+	}
+
+	if *verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
+
+	args = flags.Args()
+	if len(args) != 1 {
+		return errors.New("base url is required")
+	}
+	baseURL := strings.TrimSuffix(args[0], "/")
+	initialURL := baseURL + "/redirect/headers"
+	destinationPrefix := baseURL + "/get/headers"
+
+	ctx, cancel := chromedp.NewRemoteAllocator(ctx,
+		*cdpws, chromedp.NoModifyURL,
+	)
+	defer cancel()
+
+	// build context options
+	var opts []chromedp.ContextOption
+	if *verbose {
+		opts = append(opts, chromedp.WithDebugf(log.Printf))
+	}
+
+	ctx, cancel = chromedp.NewContext(ctx, opts...)
+	defer cancel()
+
+	// ensure the first tab is created
+	if err := chromedp.Run(ctx); err != nil {
+		return fmt.Errorf("new tab: %w", err)
+	}
+
+	var mu sync.Mutex
+	var pauses []pause
+
+	chromedp.ListenTarget(ctx, func(ev any) {
+		switch ev := ev.(type) {
+		case *fetch.EventRequestPaused:
+			evURL := ev.Request.URL
+			relevant := evURL == initialURL || strings.HasPrefix(evURL, destinationPrefix)
+			if relevant {
+				headers := make(map[string]string, len(ev.Request.Headers))
+				for name, value := range ev.Request.Headers {
+					headers[name] = fmt.Sprint(value)
+				}
+				mu.Lock()
+				pauses = append(pauses, pause{
+					requestID: string(ev.RequestID),
+					networkID: string(ev.NetworkID),
+					url:       evURL,
+					headers:   headers,
+				})
+				mu.Unlock()
+			}
+
+			go func() {
+				req := fetch.ContinueRequest(ev.RequestID)
+				if evURL == initialURL {
+					entries := []*fetch.HeaderEntry{{Name: "x-lightpanda-probe", Value: "initial"}}
+					for name, value := range ev.Request.Headers {
+						entries = append(entries, &fetch.HeaderEntry{Name: name, Value: fmt.Sprint(value)})
+					}
+					req = req.WithHeaders(entries)
+				}
+				if err := chromedp.Run(ctx, req); err != nil {
+					fmt.Fprintf(os.Stderr, "continueRequest %s: %v\n", ev.RequestID, err)
+				}
+			}()
+		}
+	})
+
+	if err := chromedp.Run(ctx,
+		fetch.Enable().WithPatterns(nil),
+	); err != nil {
+		return fmt.Errorf("fetch enable: %w", err)
+	}
+
+	if err := chromedp.Run(ctx, chromedp.Navigate(initialURL)); err != nil {
+		return fmt.Errorf("navigate %s: %w", initialURL, err)
+	}
+
+	var search, preText string
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(`location.search`, &search),
+		chromedp.Evaluate(`document.querySelector('pre').textContent`, &preText),
+	); err != nil {
+		return fmt.Errorf("read destination page: %w", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(pauses) != 2 {
+		return fmt.Errorf("expected 2 paused requests, got %d: %+v", len(pauses), pauses)
+	}
+	if pauses[0].url != initialURL {
+		return fmt.Errorf("first pause is not the initial request: %s", pauses[0].url)
+	}
+	if !strings.HasPrefix(pauses[1].url, destinationPrefix) {
+		return fmt.Errorf("second pause is not the redirect target: %s", pauses[1].url)
+	}
+	if pauses[0].requestID == pauses[1].requestID {
+		return fmt.Errorf("redirect pause must get a fresh requestId, got %s twice", pauses[0].requestID)
+	}
+	if pauses[0].networkID != pauses[1].networkID {
+		return fmt.Errorf("networkId must be stable across the redirect: %s != %s", pauses[0].networkID, pauses[1].networkID)
+	}
+	for name := range pauses[1].headers {
+		if strings.EqualFold(name, "x-lightpanda-probe") {
+			return errors.New("header override leaked into the redirected request (pause view)")
+		}
+	}
+
+	// The redirect endpoint echoes the received probe header into the
+	// Location query string: the override reached the first hop.
+	query, err := url.ParseQuery(strings.TrimPrefix(search, "?"))
+	if err != nil {
+		return fmt.Errorf("parse landing query %q: %w", search, err)
+	}
+	if query.Get("probe") != "initial" {
+		return fmt.Errorf("header override did not reach the initial request: %q", search)
+	}
+
+	// /get/headers serves the headers of the request it received as JSON.
+	var served map[string][]string
+	if err := json.Unmarshal([]byte(preText), &served); err != nil {
+		return fmt.Errorf("parse served headers %q: %w", preText, err)
+	}
+	for name := range served {
+		if strings.EqualFold(name, "x-lightpanda-probe") {
+			return errors.New("header override leaked into the redirected request (server view)")
+		}
+	}
+
+	fmt.Fprintf(stdout, "pauses: %s -> %s (networkId %s)\n", pauses[0].requestID, pauses[1].requestID, pauses[0].networkID)
+
+	return nil
+}
+
+// env returns the env value corresponding to the key or the default string.
+func env(key, dflt string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return dflt
+	}
+
+	return val
+}

--- a/playwright/request_interception_redirect.js
+++ b/playwright/request_interception_redirect.js
@@ -1,0 +1,113 @@
+// Copyright 2023-2026 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end test for request interception through an auxiliary CDP session
+// (lightpanda PR #3122 + the redirect re-pause follow-up). Playwright
+// implements browserContext.newCDPSession(page) by calling
+// Target.attachToTarget through its browser session; the returned session
+// must be a NEW session distinct from the one Playwright already uses to
+// drive the page, otherwise Playwright's session bookkeeping breaks.
+//
+// The test enables Fetch through the auxiliary session and navigates to
+// /redirect/headers, which 302s to /get/headers. It asserts that:
+//   - newCDPSession works and Fetch events arrive on that session,
+//   - both the initial request and the redirected request are paused, each
+//     with a fresh requestId but a stable networkId (Chromium semantics),
+//   - a header override applied via Fetch.continueRequest on the initial
+//     request reaches the first server (echoed back as a ?probe= query param
+//     on the redirect Location) but is NOT re-applied to the redirected
+//     request (Chromium limits overrides to a single network hop).
+//
+// Unrelated paused requests (e.g. Chrome's favicon fetch) are continued and
+// ignored, so the test also runs against real Chrome for comparison.
+
+import { chromium } from 'playwright-core';
+import assert from 'assert';
+
+// browserAddress
+const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
+
+// web serveur url
+const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
+
+const initialUrl = baseURL + '/redirect/headers';
+const destinationPrefix = baseURL + '/get/headers';
+
+const browser = await chromium.connectOverCDP(browserAddress);
+
+const context = await browser.newContext();
+const page = await context.newPage();
+
+try {
+    // https://github.com/lightpanda-io/browser/pull/3122
+    const session = await context.newCDPSession(page);
+
+    const pauses = [];
+    const continuationErrors = [];
+    session.on('Fetch.requestPaused', async (event) => {
+        const url = event.request.url;
+        const params = { requestId: event.requestId };
+        if (url === initialUrl || url.startsWith(destinationPrefix)) {
+            pauses.push({ url, requestId: event.requestId, networkId: event.networkId, headers: event.request.headers });
+            if (url === initialUrl) {
+                params.headers = Object.entries({
+                    ...event.request.headers,
+                    'x-lightpanda-probe': 'initial',
+                }).map(([name, value]) => ({ name, value: String(value) }));
+            }
+        }
+        try {
+            await session.send('Fetch.continueRequest', params);
+        } catch (error) {
+            continuationErrors.push(error);
+        }
+    });
+
+    await session.send('Fetch.enable', {
+        patterns: [{ urlPattern: '*', requestStage: 'Request' }],
+    });
+
+    const response = await page.goto(initialUrl, { timeout: 5000 });
+    assert.equal(response.status(), 200);
+    assert.equal(continuationErrors.length, 0, `continueRequest failed: ${continuationErrors[0]}`);
+
+    // Both hops must be paused: the initial request and the redirect target.
+    assert.equal(pauses.length, 2, `expected 2 paused requests, got: ${pauses.map((p) => p.url)}`);
+    assert.equal(pauses[0].url, initialUrl);
+    assert.ok(pauses[1].url.startsWith(destinationPrefix), `unexpected second hop: ${pauses[1].url}`);
+
+    // Fresh requestId per pause, stable networkId across the chain.
+    assert.notEqual(pauses[0].requestId, pauses[1].requestId, 'redirect pause must get a fresh requestId');
+    assert.equal(pauses[0].networkId, pauses[1].networkId, 'networkId must be stable across the redirect');
+
+    // The override must not appear on the redirected request's pause.
+    const hop2Names = Object.keys(pauses[1].headers).map((h) => h.toLowerCase());
+    assert.ok(!hop2Names.includes('x-lightpanda-probe'), 'header override leaked into the redirected request (pause view)');
+
+    // The redirect endpoint echoes the x-lightpanda-probe header it received
+    // into the Location query string: the override reached the first hop.
+    const landed = new URL(page.url());
+    assert.equal(landed.searchParams.get('probe'), 'initial', 'header override did not reach the initial request');
+
+    // /get/headers serves the headers of the request it received as JSON,
+    // rendered in a <pre>. The override must not survive the redirect.
+    const headers = JSON.parse(await page.locator('pre').textContent());
+    for (const name of Object.keys(headers)) {
+        assert.notEqual(name.toLowerCase(), 'x-lightpanda-probe', 'header override leaked into the redirected request (server view)');
+    }
+} finally {
+    await page.close();
+    await context.close();
+    await browser.close();
+}

--- a/puppeteer/cdp_session_redirect.js
+++ b/puppeteer/cdp_session_redirect.js
@@ -1,0 +1,90 @@
+// Copyright 2023-2026 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict'
+
+// Puppeteer variant of playwright/cdp_session_redirect.js: drive Fetch
+// interception through a raw CDP session (page.createCDPSession attaches an
+// auxiliary session via Target.attachToTarget) and navigate through a 302.
+// Asserts both hops are paused with fresh requestIds and a stable networkId,
+// and that a header override on the initial request does not survive the
+// redirect. See the playwright test for the full scenario description.
+
+import assert from 'assert';
+import { connectBrowser } from './helpers.js'
+
+// web serveur url
+const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
+
+const initialUrl = baseURL + '/redirect/headers';
+const destinationPrefix = baseURL + '/get/headers';
+
+const browser = await connectBrowser();
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+
+try {
+    const session = await page.createCDPSession();
+
+    const pauses = [];
+    const continuationErrors = [];
+    session.on('Fetch.requestPaused', async (event) => {
+        const url = event.request.url;
+        const params = { requestId: event.requestId };
+        if (url === initialUrl || url.startsWith(destinationPrefix)) {
+            pauses.push({ url, requestId: event.requestId, networkId: event.networkId, headers: event.request.headers });
+            if (url === initialUrl) {
+                params.headers = Object.entries({
+                    ...event.request.headers,
+                    'x-lightpanda-probe': 'initial',
+                }).map(([name, value]) => ({ name, value: String(value) }));
+            }
+        }
+        try {
+            await session.send('Fetch.continueRequest', params);
+        } catch (error) {
+            continuationErrors.push(error);
+        }
+    });
+
+    await session.send('Fetch.enable', {
+        patterns: [{ urlPattern: '*', requestStage: 'Request' }],
+    });
+
+    const response = await page.goto(initialUrl, { waitUntil: 'load', timeout: 5000 });
+    assert.equal(response.status(), 200);
+    assert.equal(continuationErrors.length, 0, `continueRequest failed: ${continuationErrors[0]}`);
+
+    assert.equal(pauses.length, 2, `expected 2 paused requests, got: ${pauses.map((p) => p.url)}`);
+    assert.equal(pauses[0].url, initialUrl);
+    assert.ok(pauses[1].url.startsWith(destinationPrefix), `unexpected second hop: ${pauses[1].url}`);
+
+    assert.notEqual(pauses[0].requestId, pauses[1].requestId, 'redirect pause must get a fresh requestId');
+    assert.equal(pauses[0].networkId, pauses[1].networkId, 'networkId must be stable across the redirect');
+
+    const hop2Names = Object.keys(pauses[1].headers).map((h) => h.toLowerCase());
+    assert.ok(!hop2Names.includes('x-lightpanda-probe'), 'header override leaked into the redirected request (pause view)');
+
+    const landed = new URL(page.url());
+    assert.equal(landed.searchParams.get('probe'), 'initial', 'header override did not reach the initial request');
+
+    const element = await page.$('pre');
+    const served = JSON.parse(await page.evaluate((el) => el.textContent, element));
+    for (const name of Object.keys(served)) {
+        assert.notEqual(name.toLowerCase(), 'x-lightpanda-probe', 'header override leaked into the redirected request (server view)');
+    }
+} finally {
+    await page.close();
+    await context.close();
+    await browser.disconnect();
+}

--- a/runner/main.go
+++ b/runner/main.go
@@ -173,7 +173,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"playwright/download.js"}},
 		{Bin: "node", Args: []string{"playwright/request_interception.js"}},
 		{Bin: "node", Args: []string{"playwright/request_interception_cache.js"}},
-		{Bin: "node", Args: []string{"playwright/cdp_session_redirect.js"}},
+		{Bin: "node", Args: []string{"playwright/request_interception_redirect.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache-disable.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache-vary.js"}},

--- a/runner/main.go
+++ b/runner/main.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -153,6 +154,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"puppeteer/request_interception.js"}},
 		{Bin: "node", Args: []string{"puppeteer/request_interception_cache.js"}},
 		{Bin: "node", Args: []string{"puppeteer/request_interception_redirect.js"}},
+		{Bin: "node", Args: []string{"puppeteer/cdp_session_redirect.js"}},
 		{Bin: "node", Args: []string{"puppeteer/authenticate.js"}},
 		{Bin: "node", Args: []string{"puppeteer/ri_authenticate.js"}},
 		{Bin: "node", Args: []string{"puppeteer/ua.js"}},
@@ -171,6 +173,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"playwright/download.js"}},
 		{Bin: "node", Args: []string{"playwright/request_interception.js"}},
 		{Bin: "node", Args: []string{"playwright/request_interception_cache.js"}},
+		{Bin: "node", Args: []string{"playwright/cdp_session_redirect.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache-disable.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache-vary.js"}},
@@ -181,6 +184,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "go", Args: []string{"run", "links/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "click/main.go", "http://127.0.0.1:1234/"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "ri/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},
+		{Bin: "go", Args: []string{"run", "ri_redirect/main.go", "http://127.0.0.1:1234"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "fromnode/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},
 		// TODO using --pool=10 blocks the CI which timeout. We need to understand and fix the issue.
 		{Bin: "go", Args: []string{"run", "crawler/main.go", "--limit=100", "--pool=1", "http://127.0.0.1:1234/amiibo/"}, Dir: "chromedp"},
@@ -385,6 +389,11 @@ func (s DefaultServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Length", strconv.Itoa(len(downloadImage)))
 		res.Write(downloadImage)
 
+	case "/redirect/headers":
+		// Echo the interception probe header into the Location query string
+		// so the client can verify the header reached this hop, then check
+		// /get/headers to verify it was not re-applied after the redirect.
+		http.Redirect(res, req, "/get/headers?probe="+url.QueryEscape(req.Header.Get("X-Lightpanda-Probe")), http.StatusFound)
 	case "/get/headers":
 		enc := json.NewEncoder(res)
 		if err := enc.Encode(req.Header); err != nil {


### PR DESCRIPTION
Also adds Target.attachToTarget Playwright case. Extracted/adapted from: https://github.com/lightpanda-io/browser/pull/3122

It'll require 3122 and https://github.com/lightpanda-io/browser/pull/3142 to pass