### PR TITLE
Add more tests enforcing UA and Sec-Ch-Ua rules

### DIFF
--- a/puppeteer/ua-extra-headers.js
+++ b/puppeteer/ua-extra-headers.js
@@ -1,0 +1,38 @@
+'use strict'
+
+import puppeteer from 'puppeteer-core';
+import assert from 'assert';
+import { connectBrowser } from './helpers.js'
+
+const browser = await connectBrowser();
+
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+
+// Mozilla is ignored
+await page.setExtraHTTPHeaders({
+    "User-Agent": "Mozilla/5.0",
+    "Sec-Ch-Ua": "Mozilla/5.0",
+});
+
+let resp = await page.goto('http://127.0.0.1:1234/get/headers', {waitUntil: 'load'});
+let headers = await resp.json();
+
+assert.equal(headers['User-Agent'], "Lightpanda/1.0");
+assert.equal(headers['Sec-Ch-Ua'], '"Lightpanda";v="1"');
+
+// Override UA
+await page.setExtraHTTPHeaders({
+    "User-Agent": "foo/bar",
+    "Sec-Ch-Ua": "foo/bar",
+});
+
+resp = await page.goto('http://127.0.0.1:1234/get/headers', {waitUntil: 'load'});
+headers = await resp.json();
+
+assert.equal(headers['User-Agent'], "foo/bar");
+assert.equal(headers['Sec-Ch-Ua'], '"Lightpanda";v="1"');
+
+await page.close();
+await context.close();
+await browser.disconnect();

--- a/puppeteer/ua-ri.js
+++ b/puppeteer/ua-ri.js
@@ -1,0 +1,49 @@
+'use strict'
+
+import puppeteer from 'puppeteer-core';
+import assert from 'assert';
+import { connectBrowser } from './helpers.js'
+
+const browser = await connectBrowser();
+
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+
+let override_value = "";
+
+await page.setRequestInterception(true);
+page.on("request", (req) => {
+  if (req.isInterceptResolutionHandled()) return;
+
+  const headers = Object.assign({}, req.headers(), {
+    "User-Agent": override_value,
+    "Sec-Ch-Ua": override_value,
+  });
+
+  req.continue({ headers });
+});
+
+// Overriding UA with Mozilla via request interception must be ignored.
+override_value = "Mozilla/5.0"
+
+let resp = await page.goto('http://127.0.0.1:1234/get/headers', {waitUntil: 'load'});
+let headers = await resp.json();
+
+assert.equal(headers['User-Agent'], "Lightpanda/1.0");
+assert.equal(headers['Sec-Ch-Ua'], '"Lightpanda";v="1"');
+
+// Overriding UA via request interception is allowed.
+override_value = "foo/bar"
+
+resp = await page.goto('http://127.0.0.1:1234/get/headers', {waitUntil: 'load'});
+headers = await resp.json();
+
+assert.equal(headers['User-Agent'], "foo/bar");
+assert.equal(headers['Sec-Ch-Ua'], '"Lightpanda";v="1"');
+
+resp = await page.goto('http://127.0.0.1:1234/get/headers', {waitUntil: 'load'});
+headers= await resp.json();
+
+await page.close();
+await context.close();
+await browser.disconnect();

--- a/puppeteer/ua-webapi.js
+++ b/puppeteer/ua-webapi.js
@@ -1,0 +1,41 @@
+'use strict'
+
+import puppeteer from 'puppeteer-core';
+import assert from 'assert';
+import { connectBrowser } from './helpers.js'
+
+const browser = await connectBrowser();
+
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+
+// Load a page first so fetch runs from the same origin.
+await page.goto('http://127.0.0.1:1234/get/headers', {waitUntil: 'load'});
+
+const fetchHeaders = async (value) => {
+  return await page.evaluate(async (value) => {
+    const resp = await fetch('/get/headers', {
+      headers: {
+        "User-Agent": value,
+        "Sec-Ch-Ua": value,
+      },
+    });
+    return await resp.json();
+  }, value);
+};
+
+// Overriding UA with Mozilla via fetch must be ignored.
+let headers = await fetchHeaders("Mozilla/5.0");
+
+assert.equal(headers['User-Agent'], "Lightpanda/1.0");
+assert.equal(headers['Sec-Ch-Ua'], '"Lightpanda";v="1"');
+
+// Overriding UA via fetch is allowed.
+headers = await fetchHeaders("foo/bar");
+
+assert.equal(headers['User-Agent'], "foo/bar");
+assert.equal(headers['Sec-Ch-Ua'], '"Lightpanda";v="1"');
+
+await page.close();
+await context.close();
+await browser.disconnect();

--- a/runner/main.go
+++ b/runner/main.go
@@ -159,6 +159,8 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"puppeteer/authenticate.js"}},
 		{Bin: "node", Args: []string{"puppeteer/ri_authenticate.js"}},
 		{Bin: "node", Args: []string{"puppeteer/ua.js"}},
+		{Bin: "node", Args: []string{"puppeteer/ua-ri.js"}},
+		{Bin: "node", Args: []string{"puppeteer/ua-extra-headers.js"}},
 		{Bin: "node", Args: []string{"puppeteer/pending-page.js"}},
 		{Bin: "node", Args: []string{"puppeteer/console-log.js"}},
 		{Bin: "node", Args: []string{"puppeteer/magic8ball.js"}, Env: []string{"RUNS=5"}},


### PR DESCRIPTION
Add more tests on override of `User-Agent` and `Sec-Ch-Ua` headers: using request interception and set extra header.