### PR TITLE
Fix crawler deadlock

### DIFF
--- a/chromedp/crawler/main.go
+++ b/chromedp/crawler/main.go
@@ -202,6 +202,13 @@ func (f Fetcher) Run(ctx context.Context, size uint, cdp string, opts *BrowserOp
 			ctx, cancel = chromedp.NewContext(ctx)
 			defer cancel()
 
+			// chromedp allocates the browser connection on the first Run and
+			// ties it to that call's context: do it here, on the long-lived
+			// one, so the per-page deadline in fetch can't take it down.
+			if err := chromedp.Run(ctx); err != nil {
+				return fmt.Errorf("fetcher %d connect: %w", i, err)
+			}
+
 			for {
 				select {
 				case <-ctx.Done():
@@ -234,16 +241,17 @@ func (f Fetcher) Run(ctx context.Context, size uint, cdp string, opts *BrowserOp
 func fetch(ctx context.Context, u *url.URL) (*Page, error) {
 	slog.Info("fetch", slog.Any("url", u))
 
+	// Bound the whole page, navigation included
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	err := chromedp.Run(ctx, chromedp.Navigate(u.String()))
 	if err != nil {
 		return nil, fmt.Errorf("navigate %v: %w", u, err)
 	}
 
-	timeoutctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	var a []*cdp.Node
-	if err := chromedp.Run(timeoutctx, chromedp.Nodes(`a[href]`, &a, chromedp.AtLeast(1))); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Nodes(`a[href]`, &a, chromedp.AtLeast(1))); err != nil {
 		return nil, fmt.Errorf("get links: %w", err)
 	}
 
@@ -316,14 +324,36 @@ func (c Crawler) end() bool {
 	return true
 }
 
+// next returns a URL that is known but not yet queued, or nil.
+func (c Crawler) next() *url.URL {
+	for _, v := range c.known {
+		if v.s == Ready {
+			return v.u
+		}
+	}
+
+	return nil
+}
+
 func (c *Crawler) Run(ctx context.Context, seed *url.URL) error {
-	c.queue <- seed
-	c.append(seed, Queue)
+	c.append(seed, Ready)
 
 	for {
+		// Offer a ready URL and drain results in the same select. A fetcher
+		// that just handed back a result may not be parked on the queue yet,
+		// so a send that can't proceed must never stop us from receiving:
+		// with nothing in flight that would deadlock both sides.
+		var queue chan<- *url.URL
+		next := c.next()
+		if next != nil {
+			queue = c.queue
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil
+		case queue <- next:
+			c.known[next.String()].s = Queue
 		case p, ok := <-c.result:
 			if !ok {
 				return nil
@@ -336,14 +366,12 @@ func (c *Crawler) Run(ctx context.Context, seed *url.URL) error {
 			}
 			v.s = Done
 
-			count := 0
 			for _, u := range p.Links {
 				// check the url to crawl limit.
 				if c.limit > 0 && len(c.known) >= c.limit {
 					break
 				}
 
-				count = 0
 				// use only links with the same domain than seed.
 				if seed.Host != u.Host {
 					slog.Debug("ignore external url", slog.Any("url", u))
@@ -355,24 +383,10 @@ func (c *Crawler) Run(ctx context.Context, seed *url.URL) error {
 				}
 				// mark url as known.
 				c.append(u, Ready)
-				count++
 			}
-			if count == 0 && c.end() {
+			if c.end() {
 				slog.Debug("no links added")
 				return nil
-			}
-		}
-
-		// non-blocking enqueue
-		for _, v := range c.known {
-			if v.s != Ready {
-				continue
-			}
-			select {
-			case c.queue <- v.u:
-				v.s = Queue
-			default:
-				// keep url in the buffer
 			}
 		}
 	}

--- a/runner/main.go
+++ b/runner/main.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
@@ -208,8 +209,8 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		}
 
 		start := time.Now()
-		if err := runtest(ctx, t); err != nil {
-			fmt.Fprintf(stdout, "=== ERR\t%s\n", t)
+		if err := runtest(ctx, t, stderr); err != nil {
+			fmt.Fprintf(stdout, "=== ERR\t%s: %v\n", t, err)
 			fails++
 			continue
 		}
@@ -240,19 +241,52 @@ func (t Test) String() string {
 	return name + " " + strings.Join(t.Args, " ")
 }
 
-func runtest(ctx context.Context, t Test) error {
+// testTimeout bounds a single test. A test that never finishes must show up
+// as an ERR with its output, not as the job timing out with no trace.
+const testTimeout = 3 * time.Minute
+
+func runtest(ctx context.Context, t Test, stderr io.Writer) error {
+	ctx, cancel := context.WithTimeout(ctx, testTimeout)
+	defer cancel()
+
 	cmd := exec.CommandContext(ctx, t.Bin, t.Args...)
 
 	cmd.Env = t.Env
 	cmd.Dir = t.Dir
+
+	// Without a verbose writer, keep the output and replay it on failure.
+	var out bytes.Buffer
 	cmd.Stdout = t.Stdout
 	cmd.Stderr = t.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run: %w", err)
+	if cmd.Stdout == nil {
+		cmd.Stdout = &out
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = &out
 	}
 
-	return nil
+	// `go run` execs the test binary as a child, which would keep our pipes
+	// open after the parent is killed: put the test in its own process group
+	// and kill the whole group on timeout.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("timeout after %v", testTimeout)
+	}
+	if out.Len() > 0 {
+		fmt.Fprintf(stderr, "--- output: %s\n%s--- end\n", t, out.Bytes())
+	}
+
+	return fmt.Errorf("run: %w", err)
 }
 
 // runhttp starts the default and broken-robots servers on consecutive ports


### PR DESCRIPTION
With -pool 1 (what browser's e2e-test uses) the Crawler can deadlock waiting for a result if the previous queue was a noop (if the fetcher wasn't receiving). This merges the two queues into the same select, so that Crawler is always able to receive results AND queue URLs.

Also added more logging to runner in the case of a hang.