### PR TITLE
wptrunner: load-resources worker/iframe/images

### DIFF
--- a/wptrunner/browser.go
+++ b/wptrunner/browser.go
@@ -74,6 +74,9 @@ func (b *ProcessBrowser) Start(ctx context.Context) error {
 		"--port", strconv.Itoa(b.Port),
 		"--ws-max-concurrent", "64",
 		"--insecure-disable-tls-host-verification",
+		"--load-resources", "iframe",
+		"--load-resources", "image",
+		"--load-resources", "worker",
 	}
 
 	if limit := b.Memlimit; limit > 0 {


### PR DESCRIPTION
Needed after https://github.com/lightpanda-io/browser/pull/3305 lands

This includes images because some tests uses images (e.g. to test our referrer policy).