### PR TITLE
Add more redirect-related tests

### DIFF
--- a/playwright/request_interception.js
+++ b/playwright/request_interception.js
@@ -19,7 +19,7 @@ import { chromium } from 'playwright-core';
 const browserAddress = process.env.BROWSER_ADDRESS ? process.env.BROWSER_ADDRESS : 'ws://127.0.0.1:9222';
 
 // web serveur url
-const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'https://doesnotexist.localhost:9832';
+const baseURL = process.env.BASE_URL ? process.env.BASE_URL : 'http://127.0.0.1:1234';
 
 // Connect to an existing browser
 console.log("Connection to browser on " + browserAddress);
@@ -44,17 +44,21 @@ const context = await browser.newContext({
 });
 
 const page = await context.newPage();
+// /nope/ does not exist: the route sends the navigation to the /xhr/post
+// page instead, then rewrites that page's XHR (url, method, headers, body)
+// before it reaches the echo endpoint.
+const xhrURL = baseURL + '/post?via=continue';
 await page.route('**', async (route, request) => {
   const url = request.url();
-  if (url === 'https://doesnotexist.localhost:9832/nope/') {
+  if (url === baseURL + '/nope/') {
     return route.continue({
-      url: "https://httpbin.io/xhr/post",
+      url: baseURL + '/xhr/post',
     });
   }
-  if (url === 'https://httpbin.io/post') {
+  if (url === baseURL + '/post') {
     return route.continue({
       method: 'POST',
-      url: 'https://HTTPBIN.io/post',
+      url: xhrURL,
       headers: {'pw-injected': 'great', 'content-type': 'application/x-www-form-urlencoded'},
       postData: 'over=9000&tea=keemun',
     });
@@ -72,9 +76,9 @@ await page.waitForFunction(() => {
 const response = await page.locator('#response').textContent();
 const data = JSON.parse(response);
 
-if (data.url !== 'http://HTTPBIN.io/post') {
+if (data.url !== xhrURL) {
   console.log(data.url);
-  throw new Error("Expected URL to be 'http://HTTPBIN.io/post'");
+  throw new Error(`Expected URL to be '${xhrURL}'`);
 }
 
 if (data.headers['Pw-Injected'] != 'great') {

--- a/puppeteer/blocked-url-redirect.js
+++ b/puppeteer/blocked-url-redirect.js
@@ -1,0 +1,76 @@
+// Copyright 2023-2026 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import puppeteer from 'puppeteer-core';
+import assert from 'assert';
+import { connectBrowser } from './helpers.js';
+
+// Network.setBlockedURLs applies to every hop of a navigation: a redirect
+// onto a blocked URL fails even though the URL we asked for is allowed.
+const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234';
+
+const browser = await connectBrowser();
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+const client = await page._client();
+
+const requestUrls = new Map();
+let failures = [];
+client.on('Network.requestWillBeSent', (event) => {
+    requestUrls.set(event.requestId, event.request.url);
+});
+client.on('Network.loadingFailed', (event) => {
+    failures.push({ url: requestUrls.get(event.requestId), reason: event.blockedReason });
+});
+
+const expectBlocked = async (target) => {
+    failures = [];
+    try {
+        await page.goto(target, {});
+        throw new Error("No block");
+    } catch (err) {
+        assert.equal("UrlBlocked", err.message.substring(0, 10));
+    }
+    assert.deepEqual(failures, [{ url: url + '/human.txt', reason: 'inspector' }]);
+};
+
+try {
+    await client.send('Network.setBlockedURLs', {
+        // Anchored on the host: a bare '*/human.txt' would also match the
+        // query string of the redirect URL.
+        urlPatterns: [{ urlPattern: url.replace(/^https?/, '*') + '/human.txt', block: true }],
+    });
+
+    await expectBlocked(url + '/human.txt');
+    console.log("OK: direct navigation blocked");
+
+    // The redirect URL is allowed; the hop it lands on is not.
+    await expectBlocked(url + '/redirect/to?to=/human.txt');
+    console.log("OK: redirect onto a blocked URL blocked");
+
+    // A redirect onto an allowed URL still goes through.
+    await page.goto(url + '/redirect/to?to=/bot.txt', {});
+    assert.equal(url + '/bot.txt', page.url());
+    console.log("OK: redirect onto an allowed URL followed");
+} finally {
+    // The blocklist is browser-wide; leave nothing behind for the next test.
+    await client.send('Network.setBlockedURLs', { urlPatterns: [] });
+}
+
+await page.goto(url + '/redirect/to?to=/human.txt', {});
+assert.equal(url + '/human.txt', page.url());
+console.log("OK: cleared blocklist lets the redirect through");
+
+await page.close();
+await context.close();
+await browser.disconnect();

--- a/puppeteer/cache-redirect-stale.js
+++ b/puppeteer/cache-redirect-stale.js
@@ -1,0 +1,72 @@
+// Copyright 2023-2026 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import puppeteer from 'puppeteer-core';
+import { connectBrowser, needsCache } from './helpers.js';
+
+// A stale cache entry is revalidated with If-None-Match / If-Modified-Since.
+// When the server answers that revalidation with a 3xx instead of a 304, the
+// validators belong to the URL they were issued for and must not follow the
+// request to the redirect target.
+//
+// /redirect-stale/script.js answers 200 (ETag + Last-Modified, max-age=1) to
+// an unconditional request and 302 → /redirect-stale/headers.js to a
+// conditional one. The target is a script that publishes the request headers
+// it received on window.echoedHeaders.
+//
+// Only subresources are cached: a root-frame navigation always skips the
+// cache, so the stale entry is the script, not the document.
+const url = 'http://127.0.0.1:1236/redirect-stale/index.html';
+
+const browser = await connectBrowser();
+await needsCache(browser);
+
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+const client = await page._client();
+
+let servedFromCache = false;
+client.on('Network.requestServedFromCache', () => {
+    servedFromCache = true;
+});
+
+const goto = () => page.goto(url, { waitUntil: 'load', timeout: 4000 });
+const echoed = () => page.evaluate(() => window.echoedHeaders ?? null);
+
+await client.send('Network.clearBrowserCache');
+
+// 1. Cold miss, stores the entry.
+await goto();
+if (servedFromCache) throw new Error("Expected cold miss");
+if (await echoed() !== null) throw new Error("Expected the first request to be unconditional");
+console.log("OK: cold miss stored the entry");
+
+// Wait for max-age=1 to expire.
+await new Promise((r) => setTimeout(r, 1500));
+
+// 2. Stale → conditional request → 302. The hop must be unconditional.
+servedFromCache = false;
+await goto();
+if (servedFromCache) throw new Error("Expected the stale entry to be revalidated");
+const headers = await echoed();
+if (headers === null) throw new Error("Expected the revalidation to be redirected to the echo script");
+for (const name of ['If-None-Match', 'If-Modified-Since']) {
+    if (name in headers) {
+        throw new Error(`${name} followed the request to the redirect target: ${headers[name]}`);
+    }
+}
+console.log("OK: validators did not follow the redirect");
+
+await page.close();
+await context.close();
+await browser.disconnect();

--- a/puppeteer/cache-redirect.js
+++ b/puppeteer/cache-redirect.js
@@ -1,0 +1,76 @@
+// Copyright 2023-2026 Lightpanda (Selecy SAS)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import puppeteer from 'puppeteer-core';
+import { connectBrowser, needsCache } from './helpers.js';
+
+// A followed redirect is a new request: the hop runs its own cache lookup.
+// index.html loads its script through a 302. The 302 carries no cache
+// headers so it is never cached, but the script it lands on is, and a second
+// visit must serve the script from the cache.
+//
+// Only subresources are cached: a root-frame navigation always skips the
+// cache, so the redirect is on the script, not the document.
+const base = 'http://127.0.0.1:1236';
+const url = `${base}/redirect-cache/index.html`;
+const redirect = `${base}/redirect/to?to=/redirect-cache/script.js`;
+const target = `${base}/redirect-cache/script.js`;
+
+const browser = await connectBrowser();
+await needsCache(browser);
+
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+const client = await page._client();
+
+// requestId → the URL of the most recent hop announced for it. The hop's
+// requestWillBeSent (with redirectResponse) precedes its cache events.
+const requestUrls = new Map();
+let servedFromCache = new Set();
+let fromDiskCache = new Set();
+
+client.on('Network.requestWillBeSent', (event) => {
+    requestUrls.set(event.requestId, event.request.url);
+});
+client.on('Network.requestServedFromCache', (event) => {
+    servedFromCache.add(requestUrls.get(event.requestId));
+});
+client.on('Network.responseReceived', (event) => {
+    if (event.response.fromDiskCache) {
+        fromDiskCache.add(event.response.url);
+    }
+});
+
+const goto = () => page.goto(url, { waitUntil: 'load', timeout: 4000 });
+const reset = () => { servedFromCache = new Set(); fromDiskCache = new Set(); };
+const loaded = () => page.evaluate(() => window.redirectedScript);
+
+await client.send('Network.clearBrowserCache');
+
+await goto();
+if (await loaded() !== true) throw new Error("Expected the redirected script to run");
+if (servedFromCache.size !== 0) throw new Error("Expected first visit to be a cache miss");
+if (fromDiskCache.size !== 0) throw new Error("Expected first visit to not be from disk cache");
+console.log("OK: first visit fetched the redirect target");
+
+reset();
+await goto();
+if (await loaded() !== true) throw new Error("Expected the redirected script to run");
+if (!servedFromCache.has(target)) throw new Error("Expected the redirect target to be served from cache");
+if (!fromDiskCache.has(target)) throw new Error("Expected the redirect target to be from disk cache");
+if (servedFromCache.has(redirect)) throw new Error("Expected the 302 itself to not be cached");
+console.log("OK: second visit served the redirect target from cache");
+
+await page.close();
+await context.close();
+await browser.disconnect();

--- a/puppeteer/lp-configure-obey-robots.js
+++ b/puppeteer/lp-configure-obey-robots.js
@@ -41,6 +41,19 @@ try {
 // bot.txt is allowed by robots.txt
 await page.goto(url + "/bot.txt", {});
 
+// A redirect is a new request: the hop we land on has to pass robots.txt on
+// its own, even though the URL we asked for is allowed.
+try {
+  await page.goto(url + "/redirect/to?to=/human.txt", {});
+  throw new Error("No block");
+} catch (err) {
+  assert.equal("RobotsBlocked", err.message.substring(0, 13))
+}
+
+// and the same redirect onto an allowed path still goes through.
+await page.goto(url + "/redirect/to?to=/bot.txt", {});
+assert.equal(url + "/bot.txt", page.url());
+
 await page.close();
 await context.close();
 await browser.disconnect();

--- a/puppeteer/wait_for_network.js
+++ b/puppeteer/wait_for_network.js
@@ -16,7 +16,7 @@
 import puppeteer from 'puppeteer-core';
 import { connectBrowser } from './helpers.js'
 
-const url = process.env.URL ? process.env.URL : 'https://httpbin.io/xhr/get';
+const url = process.env.URL ? process.env.URL : 'http://127.0.0.1:1234/xhr/get';
 const browser = await connectBrowser();
 
 // The rest of your script remains the same.

--- a/runner/main.go
+++ b/runner/main.go
@@ -170,6 +170,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"puppeteer/markdown.js"}, Env: []string{"URL=http://127.0.0.1:1234/campfire-commerce/"}},
 		{Bin: "node", Args: []string{"puppeteer/lp-configure-loading.js"}, Env: []string{"URL=http://127.0.0.1:1234/campfire-commerce/"}},
 		{Bin: "node", Args: []string{"puppeteer/lp-configure-obey-robots.js"}, Env: []string{"URL=http://127.0.0.1:1234"}},
+		{Bin: "node", Args: []string{"puppeteer/blocked-url-redirect.js"}, Env: []string{"URL=http://127.0.0.1:1234"}},
 		{Bin: "node", Args: []string{"playwright/connect.js"}},
 		{Bin: "node", Args: []string{"playwright/cdp.js"}, Env: []string{"RUNS=2"}},
 		{Bin: "node", Args: []string{"playwright/dump.js"}},
@@ -190,6 +191,8 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		{Bin: "node", Args: []string{"puppeteer/cache-no-store.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache-revalidation-etag.js"}},
 		{Bin: "node", Args: []string{"puppeteer/cache-revalidation-last-modified.js"}},
+		{Bin: "node", Args: []string{"puppeteer/cache-redirect.js"}},
+		{Bin: "node", Args: []string{"puppeteer/cache-redirect-stale.js"}},
 		{Bin: "go", Args: []string{"run", "fetch/main.go", "test"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "links/main.go", "http://127.0.0.1:1234/campfire-commerce/"}, Dir: "chromedp"},
 		{Bin: "go", Args: []string{"run", "click/main.go", "http://127.0.0.1:1234/"}, Dir: "chromedp"},
@@ -434,6 +437,59 @@ func (s DefaultServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Length", strconv.Itoa(len(downloadImage)))
 		res.Write(downloadImage)
 
+	case "/xhr/get", "/xhr/post":
+		// A page whose only network activity is one XMLHttpRequest to the
+		// echo endpoint of the same name, with the reply shown in #response.
+		// Local stand-in for httpbin.io/xhr/{get,post}.
+		method := strings.ToUpper(strings.TrimPrefix(req.URL.Path, "/xhr/"))
+		res.Header().Add("Content-Type", "text/html")
+		fmt.Fprintf(res, `<!DOCTYPE html><html><body><pre id="response"></pre><script>
+const xhr = new XMLHttpRequest();
+xhr.onload = function () {
+  if (xhr.status >= 200 && xhr.status < 300) {
+    document.getElementById('response').textContent = xhr.responseText;
+  } else {
+    console.log('The request failed!');
+  }
+};
+xhr.onerror = function () { console.log('There was an error!'); };
+xhr.open('%s', '/%s');
+xhr.send();
+</script></body></html>`, method, strings.ToLower(method))
+
+	case "/get", "/post":
+		// Echo the request as JSON in httpbin's shape: url, method, headers
+		// (one string per header) and the decoded form fields.
+		defer req.Body.Close()
+		if err := req.ParseForm(); err != nil {
+			http.Error(res, err.Error(), http.StatusBadRequest)
+			return
+		}
+		headers := make(map[string]string, len(req.Header))
+		for name, values := range req.Header {
+			headers[name] = strings.Join(values, ", ")
+		}
+		form := make(map[string]string, len(req.PostForm))
+		for name, values := range req.PostForm {
+			form[name] = strings.Join(values, ", ")
+		}
+		res.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(res)
+		err := enc.Encode(map[string]any{
+			"url":     "http://" + req.Host + req.URL.RequestURI(),
+			"method":  req.Method,
+			"headers": headers,
+			"form":    form,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "encode json: %v", err)
+		}
+
+	case "/redirect/to":
+		// Generic 302 to the ?to= target. Every gate (robots.txt, the url
+		// blocklist, the per-host throttle) has to be re-applied to the
+		// target of a redirect, not just to the URL we were asked for.
+		http.Redirect(res, req, req.URL.Query().Get("to"), http.StatusFound)
 	case "/redirect/headers":
 		// Echo the interception probe header into the Location query string
 		// so the client can verify the header reached this hop, then check
@@ -529,6 +585,46 @@ func (s *CacheServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Last-Modified", lastModified)
 		res.Header().Set("Content-Type", "text/html")
 		fmt.Fprintf(res, "document.writeln('version: %d')", current)
+
+	case path == "/redirect/to":
+		// Generic 302 to the ?to= target, same as DefaultServer's.
+		http.Redirect(res, req, req.URL.Query().Get("to"), http.StatusFound)
+
+	case path == "/redirect-cache/index.html":
+		// The script is reached through a 302: the hop has to run its own
+		// cache lookup, and be stored under its own URL.
+		res.Write([]byte("<!DOCTYPE html><script src='/redirect/to?to=/redirect-cache/script.js'></script>"))
+
+	case path == "/redirect-cache/script.js":
+		res.Header().Set("Cache-Control", "max-age=3600")
+		res.Header().Set("Content-Type", "application/javascript")
+		res.Write([]byte("window.redirectedScript = true;"))
+
+	case path == "/redirect-stale/index.html":
+		res.Write([]byte("<!DOCTYPE html><script src='script.js'></script>"))
+
+	case path == "/redirect-stale/script.js":
+		// A revalidation (conditional request) is answered with a redirect
+		// instead of a 304. The validators were issued for this URL and must
+		// not follow the request to the target, which echoes what it got.
+		if req.Header.Get("If-None-Match") != "" || req.Header.Get("If-Modified-Since") != "" {
+			http.Redirect(res, req, "/redirect-stale/headers.js", http.StatusFound)
+			return
+		}
+		res.Header().Set("Cache-Control", "max-age=1")
+		res.Header().Set("ETag", `"redirect-stale"`)
+		res.Header().Set("Last-Modified", lmForVersion(0))
+		res.Header().Set("Content-Type", "application/javascript")
+		res.Write([]byte("window.stale = true;"))
+
+	case path == "/redirect-stale/headers.js":
+		hdrs, err := json.Marshal(req.Header)
+		if err != nil {
+			http.Error(res, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		res.Header().Set("Content-Type", "application/javascript")
+		fmt.Fprintf(res, "window.echoedHeaders = %s;", hdrs)
 
 	case strings.HasPrefix(path, "/cache/"):
 		req.URL.Path = path[len("/cache"):]

--- a/webbotauth/validator.js
+++ b/webbotauth/validator.js
@@ -164,6 +164,11 @@ async function validate(headers, method, path, authority) {
   return [200, { ok: true, label, keyid: params.keyid, agent: agentUrl, components, sig_base: sigBase }];
 }
 
+// One validator handles one request and exits with its verdict. Two of them
+// on different ports make a redirect test: the signature covers @authority,
+// so a hop onto the second validator has to be re-signed for it.
+const port = parseInt(process.env.PORT ?? "8989", 10);
+
 const server = http.createServer(async (req, res) => {
   const headers = Object.fromEntries(
     Object.entries(req.headers).map(([k, v]) => [k.toLowerCase(), v])
@@ -174,14 +179,25 @@ const server = http.createServer(async (req, res) => {
 
   const [status, result] = await validate(headers, req.method, req.url, headers["host"] ?? "localhost");
 
+  // /redirect?to=<url>: a validated request is sent on to `to` instead of
+  // answered, so the next hop can be checked by another validator.
+  const url = new URL(req.url, `http://127.0.0.1:${port}`);
+  const to = url.pathname === "/redirect" && status === 200 ? url.searchParams.get("to") : null;
+
   const body = Buffer.from(JSON.stringify(result, null, 2));
-  res.writeHead(status, { "Content-Type": "application/json", "Content-Length": body.length });
-  res.end(body);
-  console.log(`[${req.method}] ${req.url} → ${status} (${body})`);
+  if (to) {
+    res.writeHead(302, { Location: to, "Content-Length": 0 });
+    res.end();
+    console.log(`[${req.method}] ${req.url} → 302 ${to}`);
+  } else {
+    res.writeHead(status, { "Content-Type": "application/json", "Content-Length": body.length });
+    res.end(body);
+    console.log(`[${req.method}] ${req.url} → ${status} (${body})`);
+  }
 
   server.close(() => process.exit(status === 200 ? 0 : 1));
 });
 
-server.listen(8989, "127.0.0.1", () => {
-  console.log(`Validator listening on http://127.0.0.1:8989 (waiting for one request)`);
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Validator listening on http://127.0.0.1:${port} (waiting for one request)`);
 });


### PR DESCRIPTION
Needs https://github.com/lightpanda-io/browser/pull/3389

Tests redirects with robots, web auth, caching, RI, ...

Removes the dependency on httpbin in some cases. It's flaky/slow for me and what we need is trivially implemented in the runner.